### PR TITLE
Implement tes262's agent tests as WPT (Window object and DedicatedWorker)

### DIFF
--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/did-timeout.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/did-timeout.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wait returns the right result when it timed out and that
+  the time to time out is reasonable.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    var worker_code = `
+      onmessage = function(e) {
+        var ia = e.data[0];
+        var then = Date.now();
+        var ret = Atomics.wait(ia, 0, 0, 500); // Timeout 500ms
+        postMessage([ret, Date.now() - then]);
+      }
+    `;
+    var onmessage = this.step_func(function(e) {
+      var ret = e.data[0];
+      var time = Math.abs(e.data[1]);
+      assert_equals(ret, "timed-out");
+      assert_true(time >= 500);
+      t.done();
+    });
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    var worker = WorkerHelper.createFromString(worker_code, onmessage);
+    worker.postMessage([ia]);
+  }, "atomics-dedicated-worker-wait-did-timeout");
+});
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/good-views.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/good-views.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+/*---
+description: >
+  Test Atomics.wait on arrays that allow atomic operations,
+  in an Agent that is allowed to wait.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    var check_done = WorkerHelper.check_done(t, 7);
+
+    var A = WorkerHelper.createFromString(`
+        onmessage = function(e) {
+            var view = e.data[0];
+            postMessage(Atomics.wait(view, 0, 0, 0));
+        }
+    `, t.step_func(function(e) {
+        assert_equals(e.data, "timed-out");
+        console.log("A");
+        check_done();
+    }));
+    var B = WorkerHelper.createFromString(`
+        onmessage = function(e) {
+            var view = e.data[0];
+            postMessage(Atomics.wait(view, 0, 37, 0));
+        }
+    `, t.step_func(function(e) {
+        assert_equals(e.data, "not-equal");
+        check_done();
+    }));
+    var C = WorkerHelper.createFromString(`
+        onmessage = function(e) {
+            var view = e.data[0];
+            var idx = e.data[1];
+            postMessage(Atomics.wait(view, idx, 0));
+        }
+    `, t.step_func(function(e) {
+        assert_equals(e.data, "not-equal");
+        check_done();
+    }));
+
+    var sab = new SharedArrayBuffer(1024);
+
+    var good_indices = [
+        (view) => 0/-1,
+        (view) => '-0',
+        (view) => view.length - 1,
+        (view) => ({ valueOf: () => 0 }),
+        (view) => ({ toString: () => '0', valueOf: false }) // non-callable valueOf triggers invocation of toString
+    ];
+
+    var view = new Int32Array(sab, 32, 20);
+
+    view[0] = 0;
+    A.postMessage([view]);
+    B.postMessage([view]);
+
+    setTimeout(function() {
+        for (var IdxGen of good_indices) {
+            let Idx = IdxGen(view);
+            view[Idx] = 0;
+            // Firefox cannot apply clone algorithm on an Object.
+            // See https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+            if (typeof Idx == "object") {
+                Idx = Idx.valueOf ? Idx.valueOf() : Idx.toString();
+            }
+            Atomics.store(view, Idx, 37);
+            C.postMessage([view, Idx]);
+        }
+    }, 500);
+  }, "atomics-dedicated-worker-wait-good-views");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/nan-timeout.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/nan-timeout.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wait does not time out with a NaN timeout
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    var worker_code = `
+      onmessage = function(e) {
+        let ia = e.data[0];
+        let ret = Atomics.wait(ia, 0, 0, NaN);
+        postMessage([ret]);
+      }
+    `;
+    var onmessage = this.step_func(function(e) {
+      let val = e.data[0];
+      assert_equals(val, "ok");
+      t.done();
+    });
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    var worker = WorkerHelper.createFromString(worker_code, onmessage);
+    worker.postMessage([ia]);
+    window.setTimeout(() => Atomics.wake(ia, 0), 500);
+  }, "atomics-dedicated-worker-wait-nan-timeout");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/negative-timeout.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/negative-timeout.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wait times out with a negative timeout
+---*/
+
+window.addEventListener("load", function(e) {
+  async_test(function(t) {
+		var worker_code = `
+			onmessage = function(e) {
+				var ia = e.data[0];
+				var ret = Atomics.wait(ia, 0, 0, -5);
+				postMessage([ret]);
+			}
+		`;
+    var onmessage = this.step_func(function(e) {
+      var ret = e.data[0];
+      assert_true(ret == "timed-out");
+      t.done();
+    })
+		var worker = WorkerHelper.createFromString(worker_code, onmessage);
+		var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia]);
+  }, "atomics-dedicated-worker-wait-negative-timeout");
+})
+
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/no-spurious-wakeup.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/no-spurious-wakeup.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+/*---
+description: >
+  Test that Atomics.wait actually waits and does not spuriously wake
+  up when the memory value is changed.
+includes: [atomicsHelper.js]
+---*/
+
+window.addEventListener("load", function(e) {
+  async_test(function(t) {
+		var worker_code = `
+			onmessage = function(e) {
+					var ia = e.data[0];
+					var then = Date.now();
+					Atomics.wait(ia, 0, 0);
+					var diff = Date.now() - then;
+					postMessage([diff]);
+			}
+		`;
+		var onmessage = this.step_func(function(e) {
+      var ret = e.data[0];
+      assert_true(Math.abs(ret) <= 1000);
+      t.done();
+    });
+
+		var worker = WorkerHelper.createFromString(worker_code, onmessage);
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia]);
+    setTimeout(function() {
+      // Change the value, should not wake the agent.
+      Atomics.store(ia, 0, 1);
+      // Wake up worker.
+      setTimeout(() => Atomics.wake(ia, 0), 500);
+    }, 500);
+  }, "atomics-wait-no-spurious-wakeup");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/was-woken.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wait/was-woken.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+window.addEventListener("load", function(e) {
+  async_test(function(t) {
+    var worker_code = `
+      onmessage = function(e) {
+        var ia = e.data[0];
+        var ret = Atomics.wait(ia, 0, 0);
+        postMessage([ret]);
+      }
+    `;
+    var onmessage = this.step_func(function(e) {
+      var ret = e.data[0];
+      assert_true(ret == "ok");
+      t.done();
+    });
+    var worker = WorkerHelper.createFromString(worker_code, onmessage);
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia]);
+    setTimeout(() => Atomics.wake(ia, 0), 500);
+  }, "atomics-dedicated-worker-was-woken");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-all-on-loc.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-all-on-loc.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes all waiters on a location, but does not
+  wake waiters on other locations.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    var check_done = WorkerHelper.check_done(t, 4);
+    var worker1 = `
+      onmessage = function(e) {
+        var ia = e.data[0];
+        var rs = Atomics.wait(ia, 0, 0);
+        postMessage(rs);
+      }
+    `;
+    var worker2 = `
+      onmessage = function(e) {
+        var ia = e.data[0];
+        var rs = Atomics.wait(ia, 1, 0, 1000);
+        postMessage(rs);
+      }
+    `;
+    var result_ok = function(e) {
+      var rs = e.data;
+      assert_equals(rs, "ok");
+      check_done();
+    }
+    var result_timeout = function(e) {
+      var rs = e.data;
+      assert_equals(rs, "timed-out");
+      check_done();
+    }
+
+    var ia = new Int32Array(new SharedArrayBuffer(2*Int32Array.BYTES_PER_ELEMENT));
+    var workers = [];
+    for (let i = 0; i < 3; i++) {
+      workers.push(WorkerHelper.createFromString(worker1, result_ok));
+    }
+    workers.push(WorkerHelper.createFromString(worker2, result_timeout));
+    setTimeout(() => Atomics.wake(ia, 0), 500);
+    WorkerHelper.broadcast(workers, ia);
+  }, "atomics-dedicated-worker-wake-all-on-loc");
+});
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-all.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-all.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes all waiters if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    var check_done = WorkerHelper.check_done(t, 3);
+    var worker_code = `
+      onmessage = function(e) {
+        var ia = e.data[0];
+        var rs = Atomics.wait(ia, 0, 0);
+        postMessage(rs);
+      }
+    `;
+    var onmessage = function(e) {
+      var rs = e.data;
+      assert_equals(rs, "ok");
+      check_done();
+    }
+
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    var workers = [];
+    workers.push(WorkerHelper.createFromString(worker_code, onmessage));
+    workers.push(WorkerHelper.createFromString(worker_code, onmessage));
+    workers.push(WorkerHelper.createFromString(worker_code, onmessage));
+    setTimeout(() => Atomics.wake(ia, 0), 500);
+    WorkerHelper.broadcast(workers, ia);
+  }, "atomics-dedicated-worker-wake-wake-all");
+});
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-in-order.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-in-order.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes agents in the order they are waiting.
+---*/
+
+// Create workers and start them all spinning.  We set atomic slots to make
+// them go into a wait, thus controlling the waiting order.  Then we wake them
+// one by one and observe the wakeup order.
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    var rs = [];
+    function check_results(rs) {
+      for (var i=0; i < 3; i++) {
+        assert_equals(rs[i], "ok");
+      }
+      t.done();
+    }
+    var workers = [];
+    for (var i=0; i < 3; i++) {
+      var w = WorkerHelper.createFromString(`
+        onmessage = function(e) {
+          var sab = e.data[0];
+          var ia = new Int32Array(sab);
+          while (Atomics.load(ia, ${i+1}) == 0);
+          postMessage(${i} + Atomics.wait(ia, 0, 0));
+        }
+      `, function (e) {
+        rs.push(e.data);
+      });
+      workers.push(w);
+    }
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*4));
+    WorkerHelper.broadcast(workers, ia.buffer);
+
+    // Make them sleep in order 0 1 2 on ia[0]
+    var i = 0;
+    var start = new Date();
+    while (i < 3) {
+      var now = new Date();
+      var diff = start - now;
+      if (diff > 500) {
+        start = now;
+        Atomics.store(ia, i+1, 1);
+        i++;
+      }
+    }
+
+    // Wake them up one at a time and check the order is 0 1 2
+    for ( var i=0 ; i < 3 ; i++ ) {
+      assert.sameValue(Atomics.wake(ia, 0, 1), 1);
+    }
+    setTimeout(check_results, 500);
+  }, "atomics-dedicated-worker-wake-in-order")
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-nan.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-nan.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes zero waiters if the count is NaN
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    var worker = `
+      onmessage = function(e) {
+        var sab = e.data[0];
+        var ia = new Int32Array(sab);
+        postMessage(Atomics.wait(ia, 0, 0, 1000)); // We may timeout eventually
+      }
+    `;
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    var workers = [];
+    workers.push(WorkerHelper.createFromString(worker, function(e) {
+      assert_equals(e.data, "timed-out");
+      t.done();
+    }));
+    WorkerHelper.broadcast(workers, ia.buffer);
+    setTimeout(() => assert_equals(Atomics.wake(ia, 0, NaN), 0), 500); // Don't actually wake it
+  }, "atomics-dedicated-worker-wake-nan");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-negative.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-negative.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes zero waiters if the count is negative
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    var worker = `
+      onmessage = function(e) {
+        var sab = e.data[0];
+        var ia = new Int32Array(sab);
+        postMessage(Atomics.wait(ia, 0, 0, 1000)); // We may timeout eventually
+      }
+    `;
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    var workers = [];
+    workers.push(WorkerHelper.createFromString(worker, function(e) {
+      assert_equals(e.data, "timed-out");
+      t.done();
+    }));
+    WorkerHelper.broadcast(workers, ia.buffer);
+    setTimeout(() => assert_equals(Atomics.wake(ia, 0, -1), 0), 500); // Don't actually wake it
+  }, "atomics-dedicated-worker-wake-negative");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-one.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-one.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes one waiter if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    var rs = [];
+    function check_results(rs) {
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "timed-out");
+      t.done();
+    }
+    var worker = `
+      onmessage = function(e) {
+        var sab = e.data[0];
+        var ia = new Int32Array(sab);
+        postMessage(Atomics.wait(ia, 0, 0, 1000)); // We may timeout eventually
+      }
+    `;
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    var workers = [];
+    var rs = [];
+    workers.push(WorkerHelper.createFromString(worker, (e) => rs.push(e.data)));
+    workers.push(WorkerHelper.createFromString(worker, (e) => rs.push(e.data)));
+    WorkerHelper.broadcast(workers, ia.buffer);
+    setTimeout(() => assert_equals(1, Atomics.wake(ia, 0, 1)), 500); // Wake one
+    setTimeout(() => check_results(rs), 2000); // Give the agents a chance to wait
+  }, "atomics-dedicated-worker-wake-one");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-two.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-two.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes two waiters if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    function check_results(rs) {
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "ok");
+      assert_equals(rs[2], "timed-out");
+      t.done();
+    }
+    var worker = `
+      onmessage = function(e) {
+        var sab = e.data[0];
+        var ia = new Int32Array(sab);
+        postMessage(Atomics.wait(ia, 0, 0, 1000)); // We may timeout eventually
+      }
+    `;
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    var workers = [];
+    var rs = [];
+    workers.push(WorkerHelper.createFromString(worker, (e) => rs.push(e.data)));
+    workers.push(WorkerHelper.createFromString(worker, (e) => rs.push(e.data)));
+    workers.push(WorkerHelper.createFromString(worker, (e) => rs.push(e.data)));
+    WorkerHelper.broadcast(workers, ia.buffer);
+    setTimeout(() => assert_equals(2, Atomics.wake(ia, 0, 2)), 500); // Wake two
+    setTimeout(() => check_results(rs), 2000); // Give the agents a chance to wait
+  }, "atomics-dedicated-worker-wake-two");
+});
+</script>

--- a/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-zero.html
+++ b/testing/web-platform/tests/atomics/dedicated-worker-agent/wake/wake-zero.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes zero waiters if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    var worker = `
+      onmessage = function(e) {
+        var sab = e.data[0];
+        var ia = new Int32Array(sab);
+        postMessage(Atomics.wait(ia, 0, 0, 1000)); // We may timeout eventually
+      }
+    `;
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    var workers = [];
+    workers.push(WorkerHelper.createFromString(worker, function(e) {
+      assert_equals(e.data, "timed-out");
+      t.done();
+    }));
+    WorkerHelper.broadcast(workers, ia.buffer);
+    setTimeout(() => assert_equals(0, Atomics.wake(ia, 0, 0)), 500); // Wake zero
+  }, "atomics-dedicated-worker-wake-two");
+});
+</script>

--- a/testing/web-platform/tests/resources/workerhelper.js
+++ b/testing/web-platform/tests/resources/workerhelper.js
@@ -1,0 +1,23 @@
+WorkerHelper = {};
+
+WorkerHelper.createFromString = function(script, onmessage) {
+    var blob = new Blob([script], {type: 'application/javascript'});
+    var w = new Worker(URL.createObjectURL(blob));
+    w.onmessage = onmessage;
+    return w;
+}
+WorkerHelper.broadcast = function(workers, sab, idx) {
+    for (w of workers) {
+        w.postMessage([sab, idx]);
+    }
+}
+// TODO: Not actually a worker related function but a function to help with async tests.
+WorkerHelper.check_done = function(t, max) {
+    var count = 0;
+    return function() {
+        count++;
+        if (count == max) {
+            t.done();
+        }
+    };
+}


### PR DESCRIPTION
This is a port of all the test262's tests that use agent API to web platform tests.

These are the test262's tests that use the agent API:

```bash
$ grep -r --include="*.js" "agent" | cut -d : -f 1 | sort -u
harness/agent_spidermonkey.js
test/built-ins/Atomics/wait/did-timeout.js
test/built-ins/Atomics/wait/good-views.js
test/built-ins/Atomics/wait/nan-timeout.js
test/built-ins/Atomics/wait/negative-timeout.js
test/built-ins/Atomics/wait/no-spurious-wakeup.js
test/built-ins/Atomics/wait/was-woken.js
test/built-ins/Atomics/wake/wake-all.js
test/built-ins/Atomics/wake/wake-all-on-loc.js
test/built-ins/Atomics/wake/wake-in-order.js
test/built-ins/Atomics/wake/wake-nan.js
test/built-ins/Atomics/wake/wake-negative.js
test/built-ins/Atomics/wake/wake-one.js
test/built-ins/Atomics/wake/wake-two.js
test/built-ins/Atomics/wake/wake-zero.js
```

There's a total of 14 tests. It's hard to run these tests directly in a browser, so I opted to rewriting them as web-platform tests. The difficulties lies down on things such as using `agent.sleep` function which cannot be coded as a tight loop that consumes n milliseconds. Instead a sleep call in the browser has to be coded as timeout and a continuation. 

So far the tests are rewritten using a DedicatedWorker (new Worker). Further work will be to create versions of the same tests for iFrame, SharedWorkers and ServiceWorkers.