### PR TITLE
Basic infrastructure to run test262's tests in a browser's worker

### DIFF
--- a/testing/web-platform/tests/resources/generate-test262-runner.pl
+++ b/testing/web-platform/tests/resources/generate-test262-runner.pl
@@ -1,0 +1,67 @@
+#!/usr/bin/env perl
+
+# Diego Pino Garcia <dpino@igalia.com>
+#
+# Helper script to generate a web-platform test feeded with several test262's tests.
+# The test runs the test262's test inside several agents (DedicatedWorker,
+# SharedWorker and ServiceWorker).
+
+use strict;
+use warnings;
+
+my $TEMPLATE = "test262-runner.template.html";
+my $OUTPUT = "../atomics/test262-runner.html";
+
+sub readfile {
+   my $filename = shift;
+   my @ret = ();
+   open my $fh, "<", $filename or die "Could not open $filename: $!";
+   while (<$fh>) {
+      push @ret, $_;
+   }
+   close $fh;
+   return join "", @ret;
+}
+
+sub build_test_list
+{
+   # Collect tests filenames (all using SharedArrayBuffer but skipping those that use agent API).
+   my @list = ();
+   my $root="test262/built-ins/";
+   my $content=`find $root -name "*.js" | xargs grep 'SharedArrayBuffer' | cut -d : -f 1 | sort -u`;
+   foreach my $filename (split "\n", $content) {
+      my $ret=`grep -c -E "agent|createRealm" $filename`;
+      if ($ret == 0) {
+         push @list, "\t\t\t"."\"/resources/$filename\"";
+      }
+   }
+   # Print out as string.
+   my @tests = ();
+   push @tests, "var tests = [";
+   push @tests, (join ",\n", @list);
+   push @tests, "\t\t"."];";
+   return join "\n", @tests;
+}
+
+sub generate_test262_runner
+{
+   my ($content, $tests) = @_;
+
+   # Replace placeholders for test list.
+   $content =~ s/###tests###/$tests/g;
+   open (my $fh, '>', $OUTPUT);
+   print $fh $content;
+   print "Generated $OUTPUT. To run it:\n";
+   print "./mach wpt-manifest-update\n";
+   print "./mach wpt /atomics/test262-runner.html\n";
+   close $fh;
+}
+
+# Read source file template.
+my $content = readfile($TEMPLATE);
+
+# Create list of tests to feed.
+my $tests = build_test_list();
+
+# Generate test262-runner.html file.
+generate_test262_runner($content, $tests);

--- a/testing/web-platform/tests/resources/test262-runner.js
+++ b/testing/web-platform/tests/resources/test262-runner.js
@@ -1,0 +1,12 @@
+importScripts('/resources/testharness.js');
+importScripts('/resources/test262harness.js');
+
+onmessage = function(e) {
+    let script = e.data[0];
+    try {
+        eval(script);
+        postMessage(["ok"]);
+    } catch (e) {
+        throw Error(e.message);
+    }
+}

--- a/testing/web-platform/tests/resources/test262-runner.template.html
+++ b/testing/web-platform/tests/resources/test262-runner.template.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+
+function runtest_in_worker(filename, worker_class)
+{
+  worker_class = worker_class || Worker;
+  let testname = filename;
+  async_test(function(t) {
+    fetch(filename)
+      .then(response => response.text())
+      .then(function(script) {
+        var w = new worker_class("/resources/test262-runner.js");
+        w.postMessage([script]);
+        w.onmessage = function(e) {
+          let ret = e.data[0];
+          if (ret == "ok") {
+            t.done();
+          }
+        }
+        w.onerror = function(e) {
+          // TODO: Fail test as quick as possible instead of waiting for a timeout.
+        }
+      });
+  }, testname);
+}
+
+window.addEventListener("load", function() {
+    ###tests###
+    for (each of tests) {
+      runtest_in_worker(each);
+    }
+});
+
+</script>


### PR DESCRIPTION
This PR allows to run several test262's tests inside a browser's worker.

test262 is not part of of gecko-dev. It's necessary to pull `test262` in `testing/web-platform/tests/resources/`. Then run the script `testing/web-platform/tests/resources/generate-test262-runner.pl`.

```bash
$ ./generate-test262-runner.pl
Generated ../atomics/test262-runner.html. To run it:
./mach wpt-manifest-update
./mach wpt /atomics/test262-runner.html
```

After that run the commands above to run the test262-runner test.

The test contains a subset of test262 tests. At this moment the tested tests are all using "SharedArrayBuffer" but which not make use of the JS agent API and the `createRealm` call. In total there are 148 tests, all of them pass when run inside a DedicatedWorker agent.

Further steps are:

- Create a wrapper for createRealm if possible.
- Increase the number of tests.
- Extend `generate-test262-runner.pl` to generate versions that also work in SharedWorkers and ServiceWorkers