### PR TITLE
A Window object cannot pass a SharedArrayBuffer to a SharedWorker

### DIFF
--- a/testing/web-platform/tests/shared-workers/cannot-clone-sab.html
+++ b/testing/web-platform/tests/shared-workers/cannot-clone-sab.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    var worker = new SharedWorker('worker/basic.js');
+
+    worker.port.start();
+
+    var sab = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+    var ia = new Int32Array(sab);
+    worker.onmessage = function(e) {
+      assert_unreached();
+    }
+    assert_throws(TypeError(), function() {
+      worker.port.postMessage([ia]);
+    }, "A SharedArrayBuffer cannot be cloned in this context");
+    t.done();
+  }, "cannot-clone-shared-array-buffer-in-a-shared-worker");
+});
+
+</script>

--- a/testing/web-platform/tests/shared-workers/worker/basic.js
+++ b/testing/web-platform/tests/shared-workers/worker/basic.js
@@ -1,0 +1,10 @@
+onconnect = function(e) {
+    var port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+        var ia = e.data[0];
+        port.postMessage(ia);
+    });
+
+    port.start();
+}


### PR DESCRIPTION
Fixes #9.