### PR TITLE
A Window object cannot pass a SharedArrayBuffer to a ServiceWorker

### DIFF
--- a/testing/web-platform/tests/service-workers/service-worker/cannot-pass-sab-to-serviceworker.https.html
+++ b/testing/web-platform/tests/service-workers/service-worker/cannot-pass-sab-to-serviceworker.https.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>Service Worker: postMessage from waiting serviceworker</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/test-helpers.sub.js"></script>
+<script>
+
+async_test(t => {
+  let script = 'resources/echo-message-to-source-worker.js';
+  let scope = 'resources/client-postmessage-sab';
+  let registration;
+  let frame;
+  service_worker_unregister_and_register(t, script, scope)
+    .then(swr => {
+      registration = swr;
+      return wait_for_state(t, registration.installing, 'activated');
+    }).then(_ => {
+      return navigator.serviceWorker.register(script + '?update', { scope: scope })
+    }).then(_ => {
+      new Promise(_ => {
+        var sab = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+        var ia = new Int32Array(sab);
+        // SharedArrayBuffer cannot be cloned in this context.
+        assert_throws("TypeError", _ => registration.active.postMessage([ia]));
+      });
+    }).then(_ => service_worker_unregister_and_done(t, scope));
+}, 'Cannot send a SharedArrayBuffer to a ServiceWorker');
+
+</script>


### PR DESCRIPTION
Fixes #11.