### PR TITLE
Window and IFrame can share SharedArrayBuffer

### DIFF
--- a/testing/web-platform/tests/shared-memory/can-share/window-and-iframe/window-and-iframe.html
+++ b/testing/web-platform/tests/shared-memory/can-share/window-and-iframe/window-and-iframe.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/workerhelper.js></script>
+
+<body>
+  <iframe id="myiframe" style="display: none" src="empty.html" ></iframe>
+</body>
+
+<!--
+  Window creates a SharedArrayBuffer that passes to the content window of an
+  IFrame in the same origin.  The content window modifies the SharedArrayBuffer
+  and sends it back to the parent Window which checks the buffer was
+  successfully modified.
+-->
+
+<script>
+
+window.addEventListener('load', function() {
+	async_test(function(t) {
+		let iframe = document.getElementById('myiframe');
+		let contentWindow = iframe.contentWindow;
+		contentWindow.onmessage = function(e) {
+			// Receive SharedArrayBuffer.
+			let sab = e.data[0];
+			let ia = new Int32Array(sab);
+			// Change ia[0] to 1 and send back SharedArrayBuffer.
+			ia[0] = 1;
+			postMessage([ia.buffer], '*');
+		}
+		window.onmessage = t.step_func_done(function(e) {
+			let sab = e.data[0];
+			let ia = new Int32Array(sab);
+			// Check ia[0] was changed to 1.
+			assert_equals(ia[0], 1);
+		});
+		let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+		contentWindow.postMessage([ia.buffer], '*');
+	});
+});
+
+</script>


### PR DESCRIPTION
A Window and the content window of an IFrame of the same origin can share a SharedArrayBuffer.

It's not possible ot reimplement all Atomic's wake and wait tests from test262, because UI threads cannot be blocked.

Fixes #7.