### PR TITLE
Implement test262's agent tests (Window->DedicatedWorker; Any Worker->DedicatedWorker)

### DIFF
--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/did-timeout/did-timeout-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/did-timeout/did-timeout-popup.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wait returns the right result when it timed out and that
+  the time to time out is reasonable.
+---*/
+
+window.addEventListener("load", function() {
+  // Window->Pop-up->Worker.
+  async_test(function(t) {
+    let popup = window.open("../empty.html", "empty");
+    popup.onmessage = function(e) {
+      let worker = new Worker('did-timeout.js');
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia]);
+      worker.onmessage = function(e) {
+        let ret = e.data[0];
+        let time = Math.abs(e.data[1]);
+        assert_equals(ret, "timed-out");
+        assert_true(time >= 500);
+        t.done();
+      };
+    }
+    popup.postMessage([], '*');
+  }, "atomics-wait-did-timeout-from-popup");
+});
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/did-timeout/did-timeout-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/did-timeout/did-timeout-shared-worker.js
@@ -1,0 +1,13 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+    let worker = new Worker('did-timeout.js');
+    worker.onmessage = function(e) {
+      port.postMessage([e.data[0], e.data[1]]);
+    }
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia]);
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/did-timeout/did-timeout-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/did-timeout/did-timeout-worker.js
@@ -1,0 +1,8 @@
+onmessage = function(e) {
+    let worker = new Worker('did-timeout.js');
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia]);
+    worker.onmessage = function(e) {
+        postMessage([e.data[0], e.data[1]]);
+    }
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/did-timeout/did-timeout.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/did-timeout/did-timeout.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+  <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wait returns the right result when it timed out and that
+  the time to time out is reasonable.
+---*/
+
+window.addEventListener("load", function() {
+  // Window->Worker.
+  async_test(function(t) {
+    let worker = new Worker('did-timeout.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      let ret = e.data[0];
+      let time = Math.abs(e.data[1]);
+      assert_equals(ret, "timed-out");
+      assert_true(time >= 500);
+    });
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia]);
+  }, "atomics-dedicated-worker-wait-did-timeout");
+  // Window->Worker->Worker.
+  async_test(function(t) {
+    let worker = new Worker('did-timeout-worker.js');
+    worker.onmessage = this.step_func(function(e) {
+      let ret = e.data[0];
+      let time = Math.abs(e.data[1]);
+      assert_equals(ret, "timed-out");
+      assert_true(time >= 500);
+      t.done();
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wait-did-timeout-from-worker");
+  // Window->SharedWorker->Worker.
+  async_test(function(t) {
+    let worker = new SharedWorker('did-timeout-shared-worker.js');
+    worker.port.onmessage = this.step_func(function(e) {
+      let ret = e.data[0];
+      let time = Math.abs(e.data[1]);
+      assert_equals(ret, "timed-out");
+      assert_true(time >= 500);
+      t.done();
+    });
+    worker.port.start();
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wait-did-timeout-from-shared-worker");
+  // Window->IFrame->Worker.
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    contentWindow.onmessage = function(e) {
+      let worker = new Worker('did-timeout.js');
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia]);
+      worker.onmessage = function(e) {
+        let ret = e.data[0];
+        let time = Math.abs(e.data[1]);
+        assert_equals(ret, "timed-out");
+        assert_true(time >= 500);
+        t.done();
+      };
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wait-did-timeout-from-iframe");
+});
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/did-timeout/did-timeout.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/did-timeout/did-timeout.js
@@ -1,0 +1,6 @@
+onmessage = function(e) {
+    let ia = e.data[0];
+    let then = Date.now();
+    let ret = Atomics.wait(ia, 0, 0, 500); // Timeout 500ms
+    postMessage([ret, Date.now() - then]);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/empty.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/empty.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title></title>
+</head>
+<body>
+
+</body>
+</html>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/good-views-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/good-views-popup.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+/*---
+description: >
+  Test Atomics.wait on arrays that allow atomic operations,
+  in an Agent that is allowed to wait.
+---*/
+
+function check_done(rs, t) {
+  if (rs.length == 7) {
+    rs.sort();
+    assert_equals(rs[0], "A timed-out");
+    assert_equals(rs[1], "B not-equal");
+    assert_equals(rs[2], "C not-equal");
+    assert_equals(rs[3], "C not-equal");
+    assert_equals(rs[4], "C not-equal");
+    assert_equals(rs[5], "C not-equal");
+    assert_equals(rs[6], "C not-equal");
+    t.done();
+  }
+}
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let popup = window.open('../empty.html', 'empty');
+    let test = this;
+    popup.onmessage = function(e) {
+      let rs = [];
+      let w1 = new Worker('wait-on-zero.js');
+      let w2 = new Worker('wait-on-fixed.js');
+      let w3 = new Worker('wait-on-index.js');
+
+      w1.onmessage = function(e) {
+        rs.push("A " + e.data);
+        check_done(rs, t);
+      };
+      w2.onmessage = function(e) {
+        rs.push("B " + e.data);
+        check_done(rs, t);
+      };
+      w3.onmessage = function(e) {
+        rs.push("C " + e.data);
+        check_done(rs, t);
+      };
+
+      let sab = new SharedArrayBuffer(1024);
+      let view = new Int32Array(sab, 32, 20);
+
+      w1.postMessage([view]);
+      w2.postMessage([view]);
+
+      let good_indices = [
+          (view) => 0/-1,
+          (view) => '-0',
+          (view) => view.length - 1,
+          (view) => ({ valueOf: () => 0 }),
+          (view) => ({ toString: () => '0', valueOf: false }) // non-callable valueOf triggers invocation of toString
+      ];
+
+      setTimeout(function() {
+          for (let idxGen of good_indices) {
+              let idx = idxGen(view);
+              view[idx] = 0;
+              // Firefox cannot apply clone algorithm on an Object.
+              // See https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+              if (typeof idx == "object") {
+                  idx = idx.valueOf ? idx.valueOf() : idx.toString();
+              }
+              Atomics.store(view, idx, 37);
+              w3.postMessage([view, idx]);
+          }
+      }, 500);
+    }
+    popup.postMessage([], '*');
+  }, "atomics-wait-good-views-from-popup");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/good-views-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/good-views-shared-worker.js
@@ -1,0 +1,55 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+    function check_done(rs) {
+        if (rs.length == 7) port.postMessage([rs]);
+    }
+
+    port.addEventListener('message', function() {
+        let rs = [];
+        let w1 = new Worker('wait-on-zero.js');
+        let w2 = new Worker('wait-on-fixed.js');
+        let w3 = new Worker('wait-on-index.js');
+
+        w1.onmessage = function(e) {
+          rs.push("A " + e.data);
+          check_done(rs);
+        };
+        w2.onmessage = function(e) {
+          rs.push("B " + e.data);
+          check_done(rs);
+        };
+        w3.onmessage = function(e) {
+          rs.push("C " + e.data);
+          check_done(rs);
+        };
+
+        let sab = new SharedArrayBuffer(1024);
+        let view = new Int32Array(sab, 32, 20);
+
+        w1.postMessage([view]);
+        w2.postMessage([view]);
+
+        let good_indices = [
+            (view) => 0/-1,
+            (view) => '-0',
+            (view) => view.length - 1,
+            (view) => ({ valueOf: () => 0 }),
+            (view) => ({ toString: () => '0', valueOf: false }) // non-callable valueOf triggers invocation of toString
+        ];
+
+        setTimeout(function() {
+            for (let idxGen of good_indices) {
+                let idx = idxGen(view);
+                view[idx] = 0;
+                // Firefox cannot apply clone algorithm on an Object.
+                // See https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+                if (typeof idx == "object") {
+                    idx = idx.valueOf ? idx.valueOf() : idx.toString();
+                }
+                Atomics.store(view, idx, 37);
+                w3.postMessage([view, idx]);
+            }
+        }, 500);
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/good-views-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/good-views-worker.js
@@ -1,0 +1,51 @@
+function check_done(rs) {
+    if (rs.length == 7) postMessage([rs]);
+}
+
+onmessage = function() {
+    let rs = [];
+    let w1 = new Worker('wait-on-zero.js');
+    let w2 = new Worker('wait-on-fixed.js');
+    let w3 = new Worker('wait-on-index.js');
+
+    w1.onmessage = function(e) {
+      rs.push("A " + e.data);
+      check_done(rs);
+    };
+    w2.onmessage = function(e) {
+      rs.push("B " + e.data);
+      check_done(rs);
+    };
+    w3.onmessage = function(e) {
+      rs.push("C " + e.data);
+      check_done(rs);
+    };
+
+    let sab = new SharedArrayBuffer(1024);
+    let view = new Int32Array(sab, 32, 20);
+
+    w1.postMessage([view]);
+    w2.postMessage([view]);
+
+    let good_indices = [
+        (view) => 0/-1,
+        (view) => '-0',
+        (view) => view.length - 1,
+        (view) => ({ valueOf: () => 0 }),
+        (view) => ({ toString: () => '0', valueOf: false }) // non-callable valueOf triggers invocation of toString
+    ];
+
+    setTimeout(function() {
+        for (let idxGen of good_indices) {
+            let idx = idxGen(view);
+            view[idx] = 0;
+            // Firefox cannot apply clone algorithm on an Object.
+            // See https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+            if (typeof idx == "object") {
+                idx = idx.valueOf ? idx.valueOf() : idx.toString();
+            }
+            Atomics.store(view, idx, 37);
+            w3.postMessage([view, idx]);
+        }
+    }, 500);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/good-views.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/good-views.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+    <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+/*---
+description: >
+  Test Atomics.wait on arrays that allow atomic operations,
+  in an Agent that is allowed to wait.
+---*/
+
+function check_done(rs, t) {
+  if (rs.length == 7) {
+    rs.sort();
+    assert_equals(rs[0], "A timed-out");
+    assert_equals(rs[1], "B not-equal");
+    assert_equals(rs[2], "C not-equal");
+    assert_equals(rs[3], "C not-equal");
+    assert_equals(rs[4], "C not-equal");
+    assert_equals(rs[5], "C not-equal");
+    assert_equals(rs[6], "C not-equal");
+    t.done();
+  }
+}
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let rs = [];
+    let w1 = new Worker('wait-on-zero.js');
+    let w2 = new Worker('wait-on-fixed.js');
+    let w3 = new Worker('wait-on-index.js');
+
+    w1.onmessage = function(e) {
+      rs.push("A " + e.data);
+      check_done(rs, t);
+    };
+    w2.onmessage = function(e) {
+      rs.push("B " + e.data);
+      check_done(rs, t);
+    };
+    w3.onmessage = function(e) {
+      rs.push("C " + e.data);
+      check_done(rs, t);
+    };
+
+    let sab = new SharedArrayBuffer(1024);
+    let view = new Int32Array(sab, 32, 20);
+
+    w1.postMessage([view]);
+    w2.postMessage([view]);
+
+    let good_indices = [
+        (view) => 0/-1,
+        (view) => '-0',
+        (view) => view.length - 1,
+        (view) => ({ valueOf: () => 0 }),
+        (view) => ({ toString: () => '0', valueOf: false }) // non-callable valueOf triggers invocation of toString
+    ];
+
+    setTimeout(function() {
+        for (let idxGen of good_indices) {
+            let idx = idxGen(view);
+            view[idx] = 0;
+            // Firefox cannot apply clone algorithm on an Object.
+            // See https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+            if (typeof idx == "object") {
+                idx = idx.valueOf ? idx.valueOf() : idx.toString();
+            }
+            Atomics.store(view, idx, 37);
+            w3.postMessage([view, idx]);
+        }
+    }, 500);
+  }, "atomics-dedicated-worker-wait-good-views");
+  async_test(function(t) {
+    let worker = new Worker('good-views-worker.js');
+    worker.onmessage = function(e) {
+      check_done(e.data[0], t);
+    };
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wait-good-views-from-worker");
+  async_test(function(t) {
+    let worker = new SharedWorker('good-views-shared-worker.js');
+    worker.port.start();
+    worker.port.onmessage = function(e) {
+      check_done(e.data[0], t);
+    };
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wait-good-views-from-shared-worker");
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let rs = [];
+      let w1 = new Worker('wait-on-zero.js');
+      let w2 = new Worker('wait-on-fixed.js');
+      let w3 = new Worker('wait-on-index.js');
+
+      w1.onmessage = function(e) {
+        rs.push("A " + e.data);
+        check_done(rs, t);
+      };
+      w2.onmessage = function(e) {
+        rs.push("B " + e.data);
+        check_done(rs, t);
+      };
+      w3.onmessage = function(e) {
+        rs.push("C " + e.data);
+        check_done(rs, t);
+      };
+
+      let sab = new SharedArrayBuffer(1024);
+      let view = new Int32Array(sab, 32, 20);
+
+      w1.postMessage([view]);
+      w2.postMessage([view]);
+
+      let good_indices = [
+          (view) => 0/-1,
+          (view) => '-0',
+          (view) => view.length - 1,
+          (view) => ({ valueOf: () => 0 }),
+          (view) => ({ toString: () => '0', valueOf: false }) // non-callable valueOf triggers invocation of toString
+      ];
+
+      setTimeout(function() {
+          for (let idxGen of good_indices) {
+              let idx = idxGen(view);
+              view[idx] = 0;
+              // Firefox cannot apply clone algorithm on an Object.
+              // See https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+              if (typeof idx == "object") {
+                  idx = idx.valueOf ? idx.valueOf() : idx.toString();
+              }
+              Atomics.store(view, idx, 37);
+              w3.postMessage([view, idx]);
+          }
+      }, 500);
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wait-good-views-from-iframe");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/wait-on-fixed.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/wait-on-fixed.js
@@ -1,0 +1,4 @@
+onmessage = function(e) {
+    let view = e.data[0];
+    postMessage(Atomics.wait(view, 0, 37, 0));
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/wait-on-index.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/wait-on-index.js
@@ -1,0 +1,5 @@
+onmessage = function(e) {
+    let view = e.data[0];
+    let idx = e.data[1];
+    postMessage(Atomics.wait(view, idx, 0));
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/wait-on-zero.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/good-views/wait-on-zero.js
@@ -1,0 +1,4 @@
+onmessage = function(e) {
+    let view = e.data[0];
+    postMessage(Atomics.wait(view, 0, 0, 0));
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/nan-timeout/nan-timeout-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/nan-timeout/nan-timeout-popup.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wait does not time out with a NaN timeout
+---*/
+
+window.addEventListener("load", function() {
+  // Window->Pop-up->Worker.
+  async_test(function(t) {
+    let popup = window.open("../empty.html", "empty");
+    let test = this;
+    popup.onmessage = function(e) {
+      let worker = new Worker('nan-timeout.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        assert_equals(e.data[0], "ok");
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia]);
+      setTimeout(() => Atomics.wake(ia, 0), 500);
+    }
+    popup.postMessage([], '*');
+  }, "atomics-dedicated-worker-wait-nan-timeout-from-popup-window");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/nan-timeout/nan-timeout-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/nan-timeout/nan-timeout-shared-worker.js
@@ -1,0 +1,14 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+    let worker = new Worker('nan-timeout.js');
+    worker.onmessage = function(e) {
+      port.postMessage([e.data[0], e.data[1]]);
+    }
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia]);
+        setTimeout(() => Atomics.wake(ia, 0), 500);
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/nan-timeout/nan-timeout-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/nan-timeout/nan-timeout-worker.js
@@ -1,0 +1,9 @@
+onmessage = function(e) {
+    let worker = new Worker('nan-timeout.js');
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.onmessage = function(e) {
+        postMessage([e.data[0]]);
+    }
+    worker.postMessage([ia]);
+    setTimeout(() => Atomics.wake(ia, 0), 500);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/nan-timeout/nan-timeout.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/nan-timeout/nan-timeout.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+  <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wait does not time out with a NaN timeout
+---*/
+
+window.addEventListener("load", function() {
+  // Window->Worker.
+  async_test(function(t) {
+    let worker = new Worker('nan-timeout.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data[0], "ok");
+    });
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia]);
+    window.setTimeout(() => Atomics.wake(ia, 0), 500);
+  }, "atomics-dedicated-worker-wait-nan-timeout");
+  // Window->Worker->Worker.
+  async_test(function(t) {
+    let worker = new Worker('nan-timeout-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data[0], "ok");
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wait-nan-timeout-worker");
+  // Window->Worker->SharedWorker.
+  async_test(function(t) {
+    let worker = new SharedWorker('nan-timeout-shared-worker.js');
+    worker.port.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data[0], "ok");
+    });
+    worker.port.start();
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wait-nan-timeout-shared-worker");
+  // Window->IFrame->Worker.
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let that = this;
+    contentWindow.onmessage = function(e) {
+      let worker = new Worker('nan-timeout.js');
+      worker.onmessage = that.step_func_done(function(e) {
+        assert_equals(e.data[0], "ok");
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia]);
+      setTimeout(() => Atomics.wake(ia, 0), 500);
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wait-nan-timeout-from-iframe");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/nan-timeout/nan-timeout.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/nan-timeout/nan-timeout.js
@@ -1,0 +1,5 @@
+onmessage = function(e) {
+    let ia = e.data[0];
+    let ret = Atomics.wait(ia, 0, 0, NaN);
+    postMessage([ret]);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/negative-timeout/negative-timeout-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/negative-timeout/negative-timeout-popup.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wait times out with a negative timeout
+---*/
+
+window.addEventListener("load", function(e) {
+  // Window->Worker->Worker.
+  async_test(function(t) {
+    let popup = window.open('../empty.html', 'empty');
+    let test = this;
+    popup.onmessage = function() {
+      let worker = new Worker('wait-on-zero-negative.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        assert_equals(e.data, "timed-out");
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia.buffer]);
+    }
+    popup.postMessage([], '*');
+  }, "atomics-dedicated-worker-wait-negative-timeout-from-popup")
+})
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/negative-timeout/negative-timeout-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/negative-timeout/negative-timeout-shared-worker.js
@@ -1,0 +1,12 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+    port.addEventListener('message', function(e) {
+    let worker = new Worker('wait-on-zero-negative.js');
+    worker.onmessage = function(e) {
+      port.postMessage(e.data);
+    };
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia.buffer]);
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/negative-timeout/negative-timeout-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/negative-timeout/negative-timeout-worker.js
@@ -1,0 +1,8 @@
+onmessage = function() {
+    let worker = new Worker('wait-on-zero-negative.js');
+    worker.onmessage = function(e) {
+        postMessage(e.data);
+    };
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia.buffer]);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/negative-timeout/negative-timeout.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/negative-timeout/negative-timeout.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+  <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wait times out with a negative timeout
+---*/
+
+window.addEventListener("load", function(e) {
+  // Window->Worker.
+  async_test(function(t) {
+    let worker = new Worker('wait-on-zero-negative.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, "timed-out");
+    });
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia.buffer]);
+  }, "atomics-dedicated-worker-wait-negative-timeout");
+  // Window->Worker->Worker.
+  async_test(function(t) {
+    let worker = new Worker('negative-timeout-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, "timed-out");
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wait-negative-timeout-from-worker")
+  // Window->SharedWorker->Worker.
+  async_test(function(t) {
+    let worker = new SharedWorker('negative-timeout-shared-worker.js');
+    worker.port.start();
+    worker.port.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, "timed-out");
+    });
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wait-negative-timeout-from-shared-worker")
+  // Window->IFrame->Worker.
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let worker = new Worker('wait-on-zero-negative.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        assert_equals(e.data, "timed-out");
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia.buffer]);
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wait-negative-timeout-from-iframe")
+})
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/negative-timeout/wait-on-zero-negative.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/negative-timeout/wait-on-zero-negative.js
@@ -1,0 +1,4 @@
+onmessage = function(e) {
+    let ia = new Int32Array(e.data[0]);
+    postMessage(Atomics.wait(ia, 0, 0, -5));
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/no-spurious-wakeup/no-spurious-wakeup-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/no-spurious-wakeup/no-spurious-wakeup-popup.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+/*---
+description: >
+  Test that Atomics.wait actually waits and does not spuriously wake
+  up when the memory value is changed.
+includes: [atomicsHelper.js]
+---*/
+
+window.addEventListener("load", function(e) {
+  async_test(function(t) {
+    let popup = window.open('../empty.html', 'empty');
+    let test = this;
+    popup.onmessage = function(e) {
+      let worker = new Worker('wait-on-zero-diff.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        let ret = e.data[0];
+        // Running on popup window takes a bit longer than normal.
+        assert_true(Math.abs(ret) <= 3000);
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia.buffer]);
+      setTimeout(function() {
+        // Change the value, should not wake the agent.
+        Atomics.store(ia, 0, 1);
+        // Wake up worker.
+        setTimeout(() => assert_equals(1, Atomics.wake(ia, 0)), 500);
+      }, 500);
+    }
+    popup.postMessage([], '*');
+  }, "atomics-wait-no-spurious-wakeup-from-iframe");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/no-spurious-wakeup/no-spurious-wakeup-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/no-spurious-wakeup/no-spurious-wakeup-shared-worker.js
@@ -1,0 +1,18 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+    port.addEventListener('message', function(e) {
+        let worker = new Worker('wait-on-zero-diff.js');
+        worker.onmessage = function(e) {
+            port.postMessage([e.data[0]]);
+        };
+        let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+        worker.postMessage([ia.buffer]);
+        setTimeout(function() {
+            // Change the value, should not wake the agent.
+            Atomics.store(ia, 0, 1);
+            // Wake up worker.
+            setTimeout(() => Atomics.wake(ia, 0), 500);
+        }, 500);
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/no-spurious-wakeup/no-spurious-wakeup-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/no-spurious-wakeup/no-spurious-wakeup-worker.js
@@ -1,0 +1,14 @@
+onmessage = function(e) {
+  let worker = new Worker('wait-on-zero-diff.js');
+  worker.onmessage = function(e) {
+    postMessage([e.data[0]]);
+  };
+  let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+  worker.postMessage([ia.buffer]);
+  setTimeout(function() {
+    // Change the value, should not wake the agent.
+    Atomics.store(ia, 0, 1);
+    // Wake up worker.
+    setTimeout(() => Atomics.wake(ia, 0), 500);
+  }, 500);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/no-spurious-wakeup/no-spurious-wakeup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/no-spurious-wakeup/no-spurious-wakeup.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+    <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+/*---
+description: >
+  Test that Atomics.wait actually waits and does not spuriously wake
+  up when the memory value is changed.
+includes: [atomicsHelper.js]
+---*/
+
+window.addEventListener("load", function(e) {
+  async_test(function(t) {
+    let worker = new Worker('wait-on-zero-diff.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      let ret = e.data[0];
+      assert_true(Math.abs(ret) <= 1000);
+    });
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia.buffer]);
+    setTimeout(function() {
+      // Change the value, should not wake the agent.
+      Atomics.store(ia, 0, 1);
+      // Wake up worker.
+      setTimeout(() => assert_equals(1, Atomics.wake(ia, 0)), 500);
+    }, 500);
+  }, "atomics-wait-no-spurious-wakeup");
+  async_test(function(t) {
+    let worker = new Worker('no-spurious-wakeup-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      let ret = e.data[0];
+      assert_true(Math.abs(ret) <= 1000);
+    });
+    worker.postMessage([]);
+  }, "atomics-wait-no-spurious-wakeup-from-worker");
+  async_test(function(t) {
+    let worker = new SharedWorker('no-spurious-wakeup-shared-worker.js');
+    worker.port.start();
+    worker.port.onmessage = this.step_func_done(function(e) {
+      let ret = e.data[0];
+      assert_true(Math.abs(ret) <= 1000);
+    });
+    worker.port.postMessage([]);
+  }, "atomics-wait-no-spurious-wakeup-from-shared-worker");
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let worker = new Worker('wait-on-zero-diff.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        let ret = e.data[0];
+        assert_true(Math.abs(ret) <= 1000);
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia.buffer]);
+      setTimeout(function() {
+        // Change the value, should not wake the agent.
+        Atomics.store(ia, 0, 1);
+        // Wake up worker.
+        setTimeout(() => assert_equals(1, Atomics.wake(ia, 0)), 500);
+      }, 500);
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-wait-no-spurious-wakeup-from-iframe");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/no-spurious-wakeup/wait-on-zero-diff.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/no-spurious-wakeup/wait-on-zero-diff.js
@@ -1,0 +1,7 @@
+onmessage = function(e) {
+    let ia = new Int32Array(e.data[0]);
+    let then = Date.now();
+    Atomics.wait(ia, 0, 0);
+    let diff = Date.now() - then;
+    postMessage([diff]);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/was-woken/wait-on-zero.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/was-woken/wait-on-zero.js
@@ -1,0 +1,6 @@
+onmessage = function(e) {
+    let sab = e.data[0];
+    let timeout = e.data[1] || 1000;
+    let ia = new Int32Array(sab);
+    postMessage(Atomics.wait(ia, 0, 0, timeout)); // We may timeout eventually
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/was-woken/was-woken-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/was-woken/was-woken-popup.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+window.addEventListener("load", function(e) {
+  async_test(function(t) {
+    let popup = window.open('../empty.html', 'empty');
+    let test = this;
+    popup.onmessage = function(e) {
+      let worker = new Worker('wait-on-zero.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        assert_equals(e.data, 'ok');
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia.buffer, 2000]);
+      setTimeout(() => assert_equals(1, Atomics.wake(ia, 0)), 1000);
+    }
+    popup.postMessage([], '*');
+  }, "atomics-wait-was-woken-popup");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/was-woken/was-woken-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/was-woken/was-woken-shared-worker.js
@@ -1,0 +1,14 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+        let worker = new Worker('wait-on-zero.js');
+        worker.onmessage = function(e) {
+            port.postMessage(e.data);
+        };
+        let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+        worker.postMessage([ia.buffer]);
+        setTimeout(() => Atomics.wake(ia, 0), 500);
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/was-woken/was-woken-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/was-woken/was-woken-worker.js
@@ -1,0 +1,9 @@
+onmessage = function() {
+    let worker = new Worker('wait-on-zero.js');
+    worker.onmessage = function(e) {
+        postMessage(e.data);
+    };
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia.buffer]);
+    setTimeout(() => Atomics.wake(ia, 0), 500);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wait/was-woken/was-woken.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wait/was-woken/was-woken.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+  <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+window.addEventListener("load", function(e) {
+  async_test(function(t) {
+    let worker = new Worker('wait-on-zero.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, 'ok');
+    });
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia.buffer]);
+    setTimeout(() => assert_equals(1, Atomics.wake(ia, 0)), 500);
+  }, "atomics-dedicated-worker-was-woken");
+  async_test(function(t) {
+    let worker = new Worker('was-woken-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, 'ok');
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-was-woken-from-worker");
+  async_test(function(t) {
+    let worker = new SharedWorker('was-woken-shared-worker.js');
+    worker.port.start();
+    worker.port.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, 'ok');
+    });
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-was-woken-from-shared-worker");
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let worker = new Worker('wait-on-zero.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        assert_equals(e.data, 'ok');
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia.buffer]);
+      setTimeout(() => assert_equals(1, Atomics.wake(ia, 0)), 500);
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-was-woken-from-iframe");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/empty.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/empty.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title></title>
+</head>
+<body>
+
+</body>
+</html>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wait-on-one.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wait-on-one.js
@@ -1,0 +1,6 @@
+onmessage = function(e) {
+    let sab = e.data[0];
+    let timeout = e.data[1] || 1000;
+    let ia = new Int32Array(sab);
+    postMessage(Atomics.wait(ia, 1, 0, timeout)); // We may timeout eventually
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wait-on-zero.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wait-on-zero.js
@@ -1,0 +1,6 @@
+onmessage = function(e) {
+    let sab = e.data[0];
+    let timeout = e.data[1] || 1000;
+    let ia = new Int32Array(sab);
+    postMessage(Atomics.wait(ia, 0, 0, timeout)); // We may timeout eventually
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all-on-loc/wake-all-on-loc-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all-on-loc/wake-all-on-loc-popup.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes all waiters on a location, but does not
+  wake waiters on other locations.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let popup = window.open('../empty.html', 'empty');
+    let test = this;
+    popup.onmessage = function(e) {
+      let rs = [];
+      let workers = [];
+      let nworkers = 4;
+
+      // Create three workers and make them wait on zero.
+      for (let i = 0; i < nworkers-1; i++) {
+        let w = new Worker('../wait-on-zero.js');
+        w.onmessage = function(e) {
+          rs.push(e.data);
+        }
+        workers.push(w);
+      }
+      // Make fourth worker and make it wait on one.
+      let w = new Worker('../wait-on-one.js');
+      w.onmessage = function(e) {
+        rs.push(e.data);
+      }
+      workers.push(w);
+      // Send message to all workers.
+      let ia = new Int32Array(new SharedArrayBuffer(2*Int32Array.BYTES_PER_ELEMENT));
+      for (let i = 0; i < nworkers; i++) {
+        workers[i].postMessage([ia.buffer, 2000]);
+      }
+      // Wake workers waiting on zero.
+      setTimeout(() => assert_equals(3, Atomics.wake(ia, 0)), 500);
+      // Check workers on zero woke but worker on one timed-out.
+      setTimeout(test.step_func_done(function() {
+        rs.sort();
+        assert_equals(rs[0], "ok");
+        assert_equals(rs[1], "ok");
+        assert_equals(rs[2], "ok");
+        assert_equals(rs[3], "timed-out");
+      }), 2000);
+    }
+    popup.postMessage([], '*');
+  }, "atomics-wake-all-on-loc-from-popup");
+});
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all-on-loc/wake-all-on-loc-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all-on-loc/wake-all-on-loc-shared-worker.js
@@ -1,0 +1,38 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+        let rs = [];
+        let workers = [];
+        let nworkers = 4;
+
+        // Create three workers and make them wait on zero.
+        for (let i = 0; i < nworkers-1; i++) {
+            let w = new Worker('../wait-on-zero.js');
+            w.onmessage = function(e) {
+                rs.push(e.data);
+                if (rs.length == nworkers) {
+                    port.postMessage([rs]);
+                }
+            }
+            workers.push(w);
+        }
+        // Make fourth worker and make it wait on one.
+        let w = new Worker('../wait-on-one.js');
+            w.onmessage = function(e) {
+            rs.push(e.data);
+            if (rs.length == nworkers) {
+                port.postMessage([rs]);
+            }
+        }
+        workers.push(w);
+        // Send message to all workers.
+        let ia = new Int32Array(new SharedArrayBuffer(2*Int32Array.BYTES_PER_ELEMENT));
+        for (let i = 0; i < nworkers; i++) {
+            workers[i].postMessage([ia.buffer]);
+        }
+        // Wake workers waiting on zero.
+        setTimeout(() => Atomics.wake(ia, 0), 500);
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all-on-loc/wake-all-on-loc-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all-on-loc/wake-all-on-loc-worker.js
@@ -1,0 +1,33 @@
+onmessage = function() {
+    let rs = [];
+    let workers = [];
+    let nworkers = 4;
+
+    // Create three workers and make them wait on zero.
+    for (let i = 0; i < nworkers-1; i++) {
+        let w = new Worker('../wait-on-zero.js');
+        w.onmessage = function(e) {
+            rs.push(e.data);
+            if (rs.length == nworkers) {
+                postMessage([rs]);
+            }
+        }
+        workers.push(w);
+    }
+    // Make fourth worker and make it wait on one.
+    let w = new Worker('../wait-on-one.js');
+        w.onmessage = function(e) {
+        rs.push(e.data);
+        if (rs.length == nworkers) {
+            postMessage([rs]);
+        }
+    }
+    workers.push(w);
+    // Send message to all workers.
+    let ia = new Int32Array(new SharedArrayBuffer(2*Int32Array.BYTES_PER_ELEMENT));
+    for (let i = 0; i < nworkers; i++) {
+        workers[i].postMessage([ia.buffer]);
+    }
+    // Wake workers waiting on zero.
+    setTimeout(() => Atomics.wake(ia, 0), 500);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all-on-loc/wake-all-on-loc.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all-on-loc/wake-all-on-loc.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+  <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes all waiters on a location, but does not
+  wake waiters on other locations.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let rs = [];
+    let workers = [];
+    let nworkers = 4;
+
+    // Create three workers and make them wait on zero.
+    for (let i = 0; i < nworkers-1; i++) {
+      let w = new Worker('../wait-on-zero.js');
+      w.onmessage = function(e) {
+        rs.push(e.data);
+      }
+      workers.push(w);
+    }
+    // Make fourth worker and make it wait on one.
+    let w = new Worker('../wait-on-one.js');
+    w.onmessage = function(e) {
+      rs.push(e.data);
+    }
+    workers.push(w);
+    // Send message to all workers.
+    let ia = new Int32Array(new SharedArrayBuffer(2*Int32Array.BYTES_PER_ELEMENT));
+    for (let i = 0; i < nworkers; i++) {
+      workers[i].postMessage([ia.buffer]);
+    }
+    // Wake workers waiting on zero.
+    setTimeout(() => assert_equals(3, Atomics.wake(ia, 0)), 500);
+    // Check workers on zero woke but worker on one timed-out.
+    setTimeout(this.step_func_done(function() {
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "ok");
+      assert_equals(rs[2], "ok");
+      assert_equals(rs[3], "timed-out");
+    }), 2000);
+  }, "atomics-dedicated-worker-wake-all-on-loc");
+  async_test(function(t) {
+    let worker = new Worker('wake-all-on-loc-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      let rs = e.data[0];
+      rs.sort();
+      console.log("worker");
+      for (let i = 0; i < rs.length; i++) {
+        console.log("rs: " + rs[i]);
+      }
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "ok");
+      assert_equals(rs[2], "ok");
+      assert_equals(rs[3], "timed-out");
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wake-all-on-loc-from-worker");
+  async_test(function(t) {
+    let worker = new SharedWorker('wake-all-on-loc-shared-worker.js');
+    worker.port.start();
+    worker.port.onmessage = this.step_func_done(function(e) {
+      let rs = e.data[0];
+      rs.sort();
+      console.log('rs.length: ' + rs.length);
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "ok");
+      assert_equals(rs[2], "ok");
+      assert_equals(rs[3], "timed-out");
+    });
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wake-all-on-loc-from-shared-worker");
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let rs = [];
+      let workers = [];
+      let nworkers = 4;
+
+      // Create three workers and make them wait on zero.
+      for (let i = 0; i < nworkers-1; i++) {
+        let w = new Worker('../wait-on-zero.js');
+        w.onmessage = function(e) {
+          rs.push(e.data);
+        }
+        workers.push(w);
+      }
+      // Make fourth worker and make it wait on one.
+      let w = new Worker('../wait-on-one.js');
+      w.onmessage = function(e) {
+        rs.push(e.data);
+      }
+      workers.push(w);
+      // Send message to all workers.
+      let ia = new Int32Array(new SharedArrayBuffer(2*Int32Array.BYTES_PER_ELEMENT));
+      for (let i = 0; i < nworkers; i++) {
+        workers[i].postMessage([ia.buffer]);
+      }
+      // Wake workers waiting on zero.
+      setTimeout(() => assert_equals(3, Atomics.wake(ia, 0)), 500);
+      // Check workers on zero woke but worker on one timed-out.
+      setTimeout(test.step_func_done(function() {
+        rs.sort();
+        assert_equals(rs[0], "ok");
+        assert_equals(rs[1], "ok");
+        assert_equals(rs[2], "ok");
+        assert_equals(rs[3], "timed-out");
+      }), 2000);
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wake-all-on-loc-from-iframe");
+});
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all/wake-all-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all/wake-all-popup.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes all waiters if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let popup = window.open('../empty.html', 'empty');
+    let test = this;
+    popup.onmessage = function(e) {
+      let rs = [];
+      let workers = [];
+      let nworkers = 3;
+      // Create three workers and initialize them.
+      for (let i = 0; i < nworkers; i++) {
+        let w = new Worker('wake-all.js');
+        w.onmessage = function(e) {
+          rs.push(e.data);
+        }
+        workers.push(w);
+      }
+      // Send message to all workers.
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      for (let i = 0; i < nworkers; i++) {
+        workers[i].postMessage([ia.buffer, 2000]);
+      }
+      // Wake all workers.
+      setTimeout(() => assert_equals(3, Atomics.wake(ia, 0)), 500);
+      // Check all workers woke up.
+      setTimeout(test.step_func_done(function() {
+        rs.sort();
+        assert_equals(rs[0], "ok");
+        assert_equals(rs[1], "ok");
+        assert_equals(rs[2], "ok");
+      }), 2000);
+    }
+    popup.postMessage([], '*');
+  }, "atomics-wake-all-from-popup");
+});
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all/wake-all-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all/wake-all-shared-worker.js
@@ -1,0 +1,28 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+        let rs = [];
+        let workers = [];
+        let nworkers = 3;
+        // Create three workers and initialize them.
+        for (let i = 0; i < nworkers; i++) {
+          let w = new Worker('wake-all.js');
+          w.onmessage = function(e) {
+            rs.push(e.data);
+            if (rs.length == nworkers) {
+                port.postMessage([rs]);
+            }
+          }
+          workers.push(w);
+        }
+        // Send message to all workers.
+        let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+        for (let i = 0; i < nworkers; i++) {
+          workers[i].postMessage([ia.buffer]);
+        }
+        // Wake all workers.
+        setTimeout(() => Atomics.wake(ia, 0), 500);
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all/wake-all-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all/wake-all-worker.js
@@ -1,0 +1,23 @@
+onmessage = function() {
+    let rs = [];
+    let workers = [];
+    let nworkers = 3;
+    // Create three workers and initialize them.
+    for (let i = 0; i < nworkers; i++) {
+      let w = new Worker('wake-all.js');
+      w.onmessage = function(e) {
+        rs.push(e.data);
+        if (rs.length == nworkers) {
+            postMessage([rs]);
+        }
+      }
+      workers.push(w);
+    }
+    // Send message to all workers.
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    for (let i = 0; i < nworkers; i++) {
+      workers[i].postMessage([ia.buffer]);
+    }
+    // Wake all workers.
+    setTimeout(() => Atomics.wake(ia, 0), 500);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all/wake-all.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all/wake-all.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+    <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+// Copyright (C) 2015 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes all waiters if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let rs = [];
+    let workers = [];
+    let nworkers = 3;
+    // Create two workers and initialize them.
+    for (let i = 0; i < nworkers; i++) {
+      let w = new Worker('wake-all.js');
+      w.onmessage = function(e) {
+        rs.push(e.data);
+      }
+      workers.push(w);
+    }
+    // Send message to all.
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    for (let i = 0; i < nworkers; i++) {
+      workers[i].postMessage([ia.buffer]);
+    }
+    // Wake one worker.
+    setTimeout(() => assert_equals(nworkers, Atomics.wake(ia, 0)), 500);
+    // Check all workers woke.
+    setTimeout(this.step_func_done(function() {
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "ok");
+      assert_equals(rs[2], "ok");
+    }), 2000);
+  }, "atomics-dedicated-worker-wake-wake-all");
+  async_test(function(t) {
+    let worker = new Worker('wake-all-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      let rs = e.data[0];
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "ok");
+      assert_equals(rs[2], "ok");
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wake-wake-all-from-worker");
+  async_test(function(t) {
+    let worker = new SharedWorker('wake-all-shared-worker.js');
+    worker.port.start();
+    worker.port.onmessage = this.step_func_done(function(e) {
+      let rs = e.data[0];
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "ok");
+      assert_equals(rs[2], "ok");
+    });
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wake-wake-all-from-shared-worker");
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let rs = [];
+      let workers = [];
+      let nworkers = 3;
+      // Create three workers and initialize them.
+      for (let i = 0; i < nworkers; i++) {
+        let w = new Worker('wake-all.js');
+        w.onmessage = function(e) {
+          rs.push(e.data);
+        }
+        workers.push(w);
+      }
+      // Send message to all workers.
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      for (let i = 0; i < nworkers; i++) {
+        workers[i].postMessage([ia.buffer]);
+      }
+      // Wake all workers.
+      setTimeout(() => assert_equals(3, Atomics.wake(ia, 0)), 500);
+      // Check all workers woke up.
+      setTimeout(test.step_func_done(function() {
+        rs.sort();
+        assert_equals(rs[0], "ok");
+        assert_equals(rs[1], "ok");
+        assert_equals(rs[2], "ok");
+      }), 2000);
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wake-wake-all-from-iframe");
+});
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all/wake-all.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-all/wake-all.js
@@ -1,0 +1,6 @@
+onmessage = function(e) {
+    let sab = e.data[0];
+    let timeout = e.data[1] || 1000;
+    let ia = new Int32Array(sab);
+    postMessage(Atomics.wait(ia, 0, 0, timeout)); // We may timeout eventually
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-in-order/wake-in-order-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-in-order/wake-in-order-popup.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes agents in the order they are waiting.
+---*/
+
+// Create workers and start them all spinning.  We set atomic slots to make
+// them go into a wait, thus controlling the waiting order.  Then we wake them
+// one by one and observe the wakeup order.
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let popup = window.open('../empty.html', 'empty');
+    let test = this;
+    popup.onmessage = function(e) {
+      let rs = [];
+      let workers = [];
+      let nworkers = 3;
+      for (let i = 0; i < nworkers; i++) {
+        let w = new Worker('wake-in-order.js');
+        w.onmessage = function(e) {
+          rs.push({idx: e.data[0], msg: e.data[1]});
+        }
+        workers.push(w);
+      }
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*4));
+
+      for (let i = 0; i < nworkers; i++) {
+        workers[i].postMessage([i+1, ia.buffer]);
+      }
+
+      // Store on each ia slot ranging from 1-3, with a pause.
+      setTimeout(function() {
+        Atomics.store(ia, 1, 1);
+        setTimeout(function() {
+          Atomics.store(ia, 2, 1);
+          setTimeout(function() {
+            Atomics.store(ia, 3, 1);
+          }, 200);
+        }, 200);
+      }, 200);
+
+      // Wake each worker (waiting on zero), with a pause.
+      setTimeout(function() {
+        setTimeout(function() {
+          Atomics.wake(ia, 0, 1);
+          setTimeout(function() {
+            Atomics.wake(ia, 0, 1);
+            setTimeout(function() {
+              Atomics.wake(ia, 0, 1);
+            }, 200);
+          }, 200);
+        }, 200);
+      }, 1000);
+
+      // Check results.
+      setTimeout(test.step_func_done(function() {
+        for (let i = 0; i < rs.length; i++) {
+          assert_equals(rs[i].idx, i+1);
+          assert_equals(rs[i].msg, "ok");
+        }
+      }), 2000);
+    }
+    popup.postMessage([], '*');
+  }, "atomics-wake-in-order-iframe");
+});
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-in-order/wake-in-order-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-in-order/wake-in-order-shared-worker.js
@@ -1,0 +1,50 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+        let rs = [];
+        let workers = [];
+        let nworkers = 3;
+        for (let i = 0; i < nworkers; i++) {
+            let w = new Worker('wake-in-order.js');
+            w.onmessage = function(e) {
+                rs.push({idx: e.data[0], msg: e.data[1]});
+            }
+            workers.push(w);
+        }
+
+        // Send message to all workers.
+        let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*4));
+        for (let i = 0; i < nworkers; i++) {
+            workers[i].postMessage([i+1, ia.buffer]);
+        }
+
+        // Store on each ia slot ranging from 1-3, with a pause.
+        setTimeout(function() {
+            Atomics.store(ia, 1, 1);
+            setTimeout(function() {
+                Atomics.store(ia, 2, 1);
+                setTimeout(function() {
+                    Atomics.store(ia, 3, 1);
+                }, 200);
+            }, 200);
+        }, 200);
+
+        // Wake each worker (waiting on zero), with a pause.
+        setTimeout(function() {
+            setTimeout(function() {
+                Atomics.wake(ia, 0, 1);
+                setTimeout(function() {
+                    Atomics.wake(ia, 0, 1);
+                    setTimeout(function() {
+                        Atomics.wake(ia, 0, 1);
+                    }, 200);
+                }, 200);
+            }, 200);
+        }, 1000);
+
+        // Send results back.
+        setTimeout(function() { port.postMessage([rs]); }, 2000);
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-in-order/wake-in-order-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-in-order/wake-in-order-worker.js
@@ -1,0 +1,45 @@
+onmessage = function() {
+    let rs = [];
+    let workers = [];
+    let nworkers = 3;
+    for (let i = 0; i < nworkers; i++) {
+        let w = new Worker('wake-in-order.js');
+        w.onmessage = function(e) {
+            rs.push({idx: e.data[0], msg: e.data[1]});
+        }
+        workers.push(w);
+    }
+
+    // Send message to all workers.
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*4));
+    for (let i = 0; i < nworkers; i++) {
+        workers[i].postMessage([i+1, ia.buffer]);
+    }
+
+    // Store on each ia slot ranging from 1-3, with a pause.
+    setTimeout(function() {
+        Atomics.store(ia, 1, 1);
+        setTimeout(function() {
+            Atomics.store(ia, 2, 1);
+            setTimeout(function() {
+                Atomics.store(ia, 3, 1);
+            }, 200);
+        }, 200);
+    }, 200);
+
+    // Wake each worker (waiting on zero), with a pause.
+    setTimeout(function() {
+        setTimeout(function() {
+            Atomics.wake(ia, 0, 1);
+            setTimeout(function() {
+                Atomics.wake(ia, 0, 1);
+                setTimeout(function() {
+                    Atomics.wake(ia, 0, 1);
+                }, 200);
+            }, 200);
+        }, 200);
+    }, 1000);
+
+    // Send results back.
+    setTimeout(function() { postMessage([rs]); }, 2000);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-in-order/wake-in-order.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-in-order/wake-in-order.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+    <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes agents in the order they are waiting.
+---*/
+
+// Create workers and start them all spinning.  We set atomic slots to make
+// them go into a wait, thus controlling the waiting order.  Then we wake them
+// one by one and observe the wakeup order.
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let rs = [];
+    let workers = [];
+    let nworkers = 3;
+    for (let i = 0; i < nworkers; i++) {
+      let w = new Worker('wake-in-order.js');
+      w.onmessage = function(e) {
+        rs.push({idx: e.data[0], msg: e.data[1]});
+      }
+      workers.push(w);
+    }
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*4));
+
+    for (let i = 0; i < nworkers; i++) {
+      workers[i].postMessage([i+1, ia.buffer]);
+    }
+
+    // Store on each ia slot ranging from 1-3, with a pause.
+    setTimeout(function() {
+      Atomics.store(ia, 1, 1);
+      setTimeout(function() {
+        Atomics.store(ia, 2, 1);
+        setTimeout(function() {
+          Atomics.store(ia, 3, 1);
+        }, 200);
+      }, 200);
+    }, 200);
+
+    // Wake each worker (waiting on zero), with a pause.
+    setTimeout(function() {
+      setTimeout(function() {
+        Atomics.wake(ia, 0, 1);
+        setTimeout(function() {
+          Atomics.wake(ia, 0, 1);
+          setTimeout(function() {
+            Atomics.wake(ia, 0, 1);
+          }, 200);
+        }, 200);
+      }, 200);
+    }, 1000);
+
+    // Check results.
+    setTimeout(this.step_func_done(function() {
+      for (let i = 0; i < rs.length; i++) {
+        assert_equals(rs[i].idx, i+1);
+        assert_equals(rs[i].msg, "ok");
+      }
+    }), 2000);
+  }, "atomics-dedicated-worker-wake-wake-in-order");
+  async_test(function(t) {
+    let worker = new Worker('wake-in-order-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      let rs = e.data[0];
+      for (let i = 0; i < rs.length; i++) {
+        assert_equals(rs[i].idx, i+1);
+        assert_equals(rs[i].msg, "ok");
+      }
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wake-wake-in-order-worker");
+  async_test(function(t) {
+    let worker = new SharedWorker('wake-in-order-shared-worker.js');
+    worker.port.start();
+    worker.port.onmessage = this.step_func_done(function(e) {
+      let rs = e.data[0];
+      for (let i = 0; i < rs.length; i++) {
+        assert_equals(rs[i].idx, i+1);
+        assert_equals(rs[i].msg, "ok");
+      }
+    });
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wake-wake-in-order-shared-worker");
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let rs = [];
+      let workers = [];
+      let nworkers = 3;
+      for (let i = 0; i < nworkers; i++) {
+        let w = new Worker('wake-in-order.js');
+        w.onmessage = function(e) {
+          rs.push({idx: e.data[0], msg: e.data[1]});
+        }
+        workers.push(w);
+      }
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT*4));
+
+      for (let i = 0; i < nworkers; i++) {
+        workers[i].postMessage([i+1, ia.buffer]);
+      }
+
+      // Store on each ia slot ranging from 1-3, with a pause.
+      setTimeout(function() {
+        Atomics.store(ia, 1, 1);
+        setTimeout(function() {
+          Atomics.store(ia, 2, 1);
+          setTimeout(function() {
+            Atomics.store(ia, 3, 1);
+          }, 200);
+        }, 200);
+      }, 200);
+
+      // Wake each worker (waiting on zero), with a pause.
+      setTimeout(function() {
+        setTimeout(function() {
+          Atomics.wake(ia, 0, 1);
+          setTimeout(function() {
+            Atomics.wake(ia, 0, 1);
+            setTimeout(function() {
+              Atomics.wake(ia, 0, 1);
+            }, 200);
+          }, 200);
+        }, 200);
+      }, 1000);
+
+      // Check results.
+      setTimeout(test.step_func_done(function() {
+        for (let i = 0; i < rs.length; i++) {
+          assert_equals(rs[i].idx, i+1);
+          assert_equals(rs[i].msg, "ok");
+        }
+      }), 2000);
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wake-wake-in-order-iframe");
+});
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-in-order/wake-in-order.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-in-order/wake-in-order.js
@@ -1,0 +1,12 @@
+onmessage = function(e) {
+  let idx = e.data[0];
+  let buffer = e.data[1];
+  let ia = new Int32Array(buffer);
+  while (true) {
+    if (Atomics.load(ia, idx)) {
+      break;
+    }
+  }
+  let ret = Atomics.wait(ia, 0, 0);
+  postMessage([idx, ret]);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-nan/wake-nan-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-nan/wake-nan-popup.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes zero waiters if the count is NaN
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let popup = window.open("../empty.html", "empty");
+    let test = this;
+    popup.onmessage = function(e) {
+      let worker = new Worker('wake-nan.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        assert_equals(e.data, "timed-out");
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia.buffer]);
+      setTimeout(() => assert_equals(0, Atomics.wake(ia, 0, NaN)), 500); // Don't actually wake it
+    }
+    popup.postMessage([], '*');
+  }, "atomics-wake-nan-from-popup");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-nan/wake-nan-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-nan/wake-nan-shared-worker.js
@@ -1,0 +1,14 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+        let worker = new Worker('wake-nan.js');
+        worker.onmessage = function(e) {
+            port.postMessage(e.data);
+        }
+        let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+        worker.postMessage([ia.buffer]);
+        setTimeout(() => Atomics.wake(ia, 0, NaN), 500); // Don't actually wake it
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-nan/wake-nan-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-nan/wake-nan-worker.js
@@ -1,0 +1,9 @@
+onmessage = function() {
+    let worker = new Worker('wake-nan.js');
+    worker.onmessage = function(e) {
+        postMessage(e.data);
+    }
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia.buffer]);
+    setTimeout(() => Atomics.wake(ia, 0, NaN), 500); // Don't actually wake it
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-nan/wake-nan.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-nan/wake-nan.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+  <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes zero waiters if the count is NaN
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let worker = new Worker('wake-nan.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, "timed-out");
+    });
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia.buffer]);
+    setTimeout(() => assert_equals(0, Atomics.wake(ia, 0, NaN)), 500); // Don't actually wake it
+  }, "atomics-dedicated-worker-wake-nan");
+  async_test(function(t) {
+    let worker = new Worker('wake-nan-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, "timed-out");
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wake-nan-from-worker");
+  async_test(function(t) {
+    let worker = new SharedWorker('wake-nan-shared-worker.js');
+    worker.port.start();
+    worker.port.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, "timed-out");
+    });
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wake-nan-from-shared-worker");
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let worker = new Worker('wake-nan.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        assert_equals(e.data, "timed-out");
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia.buffer]);
+      setTimeout(() => assert_equals(0, Atomics.wake(ia, 0, NaN)), 500); // Don't actually wake it
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wake-nan-from-iframe");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-nan/wake-nan.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-nan/wake-nan.js
@@ -1,0 +1,5 @@
+onmessage = function(e) {
+    let sab = e.data[0];
+    let ia = new Int32Array(sab);
+    postMessage(Atomics.wait(ia, 0, 0, 1000)); // We may timeout eventually
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-negative/wake-negative-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-negative/wake-negative-popup.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes zero waiters if the count is negative
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let popup = window.open('../empty.html', 'empty');
+    let test = this;
+    popup.onmessage = function(e) {
+      let worker = new Worker('wake-negative.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        assert_equals(e.data, "timed-out");
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia.buffer]);
+      setTimeout(() => assert_equals(0, Atomics.wake(ia, 0, -1)), 500); // Don't actually wake it
+    }
+    popup.postMessage([], '*');
+  }, "atomics-wake-negative-from-popup");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-negative/wake-negative-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-negative/wake-negative-shared-worker.js
@@ -1,0 +1,14 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+        let worker = new Worker('wake-negative.js');
+        worker.onmessage = function(e) {
+            port.postMessage(e.data);
+        }
+        let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+        worker.postMessage([ia.buffer]);
+        setTimeout(() => Atomics.wake(ia, 0, -1), 500); // Don't actually wake it
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-negative/wake-negative-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-negative/wake-negative-worker.js
@@ -1,0 +1,9 @@
+onmessage = function() {
+    let worker = new Worker('wake-negative.js');
+    worker.onmessage = function(e) {
+        postMessage(e.data);
+    }
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia.buffer]);
+    setTimeout(() => Atomics.wake(ia, 0, -1), 500); // Don't actually wake it
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-negative/wake-negative.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-negative/wake-negative.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+    <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes zero waiters if the count is negative
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let worker = new Worker('wake-negative.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, "timed-out");
+    });
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia.buffer]);
+    setTimeout(() => assert_equals(0, Atomics.wake(ia, 0, -1)), 500); // Don't actually wake it
+  }, "atomics-dedicated-worker-wake-negative");
+  async_test(function(t) {
+    let worker = new Worker('wake-negative-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, "timed-out");
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wake-negative-from-worker");
+  async_test(function(t) {
+    let worker = new SharedWorker('wake-negative-shared-worker.js');
+    worker.port.onmessage = this.step_func_done(function(e) {
+      assert_equals(e.data, "timed-out");
+    });
+    worker.port.start();
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wake-negative-from-shared-worker");
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let worker = new Worker('wake-negative.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        assert_equals(e.data, "timed-out");
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia.buffer]);
+      setTimeout(() => assert_equals(0, Atomics.wake(ia, 0, -1)), 500); // Don't actually wake it
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wake-negative-from-iframe");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-negative/wake-negative.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-negative/wake-negative.js
@@ -1,0 +1,5 @@
+onmessage = function(e) {
+    let sab = e.data[0];
+    let ia = new Int32Array(sab);
+    postMessage(Atomics.wait(ia, 0, 0, 1000)); // We may timeout eventually
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-one/wake-one-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-one/wake-one-popup.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes one waiter if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let popup = window.open('../empty.html', 'empty');
+    let test = this;
+    popup.onmessage = function(e) {
+      let rs = [];
+      let workers = [];
+      // Create two workers and initialize them.
+      for (let i = 0; i < 2; i++) {
+        let w = new Worker('wake-one.js');
+        w.onmessage = function(e) {
+          rs.push(e.data);
+        }
+        workers.push(w);
+      }
+      // Send message to all broadcast.
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      for (let i = 0; i < 2; i++) {
+        workers[i].postMessage([ia.buffer, 2000]);
+      }
+      // Wake one worker.
+      setTimeout(() => assert_equals(1, Atomics.wake(ia, 0, 1)), 500);
+      // Check one worker woke up and another one timed-out.
+      setTimeout(test.step_func_done(function() {
+        rs.sort();
+        assert_equals(rs[0], "ok");
+        assert_equals(rs[1], "timed-out");
+      }), 2000);
+    }
+    popup.postMessage([], '*');
+  }, "atomics-wake-one-from-popup");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-one/wake-one-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-one/wake-one-shared-worker.js
@@ -1,0 +1,27 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+        let rs = [];
+        let workers = [];
+        // Create two workers and initialize them.
+        for (let i = 0; i < 2; i++) {
+          let w = new Worker('wake-one.js');
+          w.onmessage = function(e) {
+            rs.push(e.data);
+            if (rs.length == 2) {
+                port.postMessage([rs]);
+            }
+          }
+          workers.push(w);
+        }
+        // Send message to all broadcast.
+        let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+        for (let i = 0; i < 2; i++) {
+          workers[i].postMessage([ia.buffer]);
+        }
+        // Wake one worker.
+        setTimeout(() => Atomics.wake(ia, 0, 1), 500);
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-one/wake-one-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-one/wake-one-worker.js
@@ -1,0 +1,22 @@
+onmessage = function() {
+    let rs = [];
+    let workers = [];
+    // Create two workers and initialize them.
+    for (let i = 0; i < 2; i++) {
+      let w = new Worker('wake-one.js');
+      w.onmessage = function(e) {
+        rs.push(e.data);
+        if (rs.length == 2) {
+            postMessage([rs]);
+        }
+      }
+      workers.push(w);
+    }
+    // Send message to all broadcast.
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    for (let i = 0; i < 2; i++) {
+      workers[i].postMessage([ia.buffer]);
+    }
+    // Wake one worker.
+    setTimeout(() => Atomics.wake(ia, 0, 1), 500);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-one/wake-one.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-one/wake-one.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+  <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes one waiter if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let rs = [];
+    let workers = [];
+    // Create two workers and initialize them.
+    for (let i = 0; i < 2; i++) {
+      let w = new Worker('wake-one.js');
+      w.onmessage = function(e) {
+        rs.push(e.data);
+      }
+      workers.push(w);
+    }
+    // Send message to all broadcast.
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    for (let i = 0; i < 2; i++) {
+      workers[i].postMessage([ia.buffer]);
+    }
+    // Wake one worker.
+    setTimeout(() => assert_equals(1, Atomics.wake(ia, 0, 1)), 500);
+    // Check one worker woke up and another one timed-out.
+    setTimeout(this.step_func_done(function() {
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "timed-out");
+    }), 2000);
+  }, "atomics-dedicated-worker-wake-one");
+  async_test(function(t) {
+    let worker = new Worker('wake-one-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      let rs = e.data[0];
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "timed-out");
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wake-one-from-worker");
+  async_test(function(t) {
+    let worker = new SharedWorker('wake-one-shared-worker.js');
+    worker.port.start();
+    worker.port.onmessage = this.step_func_done(function(e) {
+      let rs = e.data[0];
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "timed-out");
+    });
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wake-one-from-shared-worker");
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let rs = [];
+      let workers = [];
+      // Create two workers and initialize them.
+      for (let i = 0; i < 2; i++) {
+        let w = new Worker('wake-one.js');
+        w.onmessage = function(e) {
+          rs.push(e.data);
+        }
+        workers.push(w);
+      }
+      // Send message to all broadcast.
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      for (let i = 0; i < 2; i++) {
+        workers[i].postMessage([ia.buffer]);
+      }
+      // Wake one worker.
+      setTimeout(() => assert_equals(1, Atomics.wake(ia, 0, 1)), 500);
+      // Check one worker woke up and another one timed-out.
+      setTimeout(test.step_func_done(function() {
+        rs.sort();
+        assert_equals(rs[0], "ok");
+        assert_equals(rs[1], "timed-out");
+      }), 2000);
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wake-one-from-iframe");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-one/wake-one.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-one/wake-one.js
@@ -1,0 +1,6 @@
+onmessage = function(e) {
+    let sab = e.data[0];
+    let timeout = e.data[1] || 1000;
+    let ia = new Int32Array(sab);
+    postMessage(Atomics.wait(ia, 0, 0, timeout)); // We may timeout eventually
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-two/wake-two-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-two/wake-two-popup.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes one waiter if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let popup = window.open("../empty.html", "empty");
+    let test = this;
+    popup.onmessage = function(e) {
+      let rs = [];
+      let workers = [];
+      let nworkers = 3;
+      // Create two workers and initialize them.
+      for (let i = 0; i < nworkers; i++) {
+        let w = new Worker('wake-two.js');
+        w.onmessage = function(e) {
+          rs.push(e.data);
+        }
+        workers.push(w);
+      }
+      // Send message to all broadcast.
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      for (let i = 0; i < nworkers; i++) {
+        workers[i].postMessage([ia.buffer, 2000]);
+      }
+      // Wake one worker.
+      setTimeout(() => assert_equals(2, Atomics.wake(ia, 0, 2)), 500);
+      // Check one worker woke up and another one timed-out.
+      setTimeout(test.step_func_done(function() {
+        rs.sort();
+        assert_equals(rs[0], "ok");
+        assert_equals(rs[1], "ok");
+        assert_equals(rs[2], "timed-out");
+      }), 2000);
+    }
+    popup.postMessage([], '*');
+  }, "atomics-wake-two-from-popup");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-two/wake-two-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-two/wake-two-shared-worker.js
@@ -1,0 +1,28 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+        let rs = [];
+        let workers = [];
+        let nworkers = 3;
+        // Create two workers and initialize them.
+        for (let i = 0; i < nworkers; i++) {
+          let w = new Worker('wake-two.js');
+          w.onmessage = function(e) {
+            rs.push(e.data);
+            if (rs.length == nworkers) {
+                port.postMessage([rs]);
+            }
+          }
+          workers.push(w);
+        }
+        // Send message to all broadcast.
+        let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+        for (let i = 0; i < nworkers; i++) {
+          workers[i].postMessage([ia.buffer]);
+        }
+        // Wake one worker.
+        setTimeout(() => Atomics.wake(ia, 0, 2), 500);
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-two/wake-two-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-two/wake-two-worker.js
@@ -1,0 +1,23 @@
+onmessage = function() {
+    let rs = [];
+    let workers = [];
+    let nworkers = 3;
+    // Create two workers and initialize them.
+    for (let i = 0; i < nworkers; i++) {
+      let w = new Worker('wake-two.js');
+      w.onmessage = function(e) {
+        rs.push(e.data);
+        if (rs.length == nworkers) {
+            postMessage([rs]);
+        }
+      }
+      workers.push(w);
+    }
+    // Send message to all broadcast.
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    for (let i = 0; i < nworkers; i++) {
+      workers[i].postMessage([ia.buffer]);
+    }
+    // Wake one worker.
+    setTimeout(() => Atomics.wake(ia, 0, 2), 500);
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-two/wake-two.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-two/wake-two.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+  <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes one waiter if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let rs = [];
+    let workers = [];
+    // Create two workers and initialize them.
+    for (let i = 0; i < 3; i++) {
+      let w = new Worker('wake-two.js');
+      w.onmessage = function(e) {
+        rs.push(e.data);
+      }
+      workers.push(w);
+    }
+    // Send message to all broadcast.
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    for (let i = 0; i < 3; i++) {
+      workers[i].postMessage([ia.buffer]);
+    }
+    // Wake one worker.
+    setTimeout(() => assert_equals(2, Atomics.wake(ia, 0, 2)), 500);
+    // Check one worker woke up and another one timed-out.
+    setTimeout(this.step_func_done(function() {
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "ok");
+      assert_equals(rs[2], "timed-out");
+    }), 2000);
+  }, "atomics-dedicated-worker-wake-two");
+  async_test(function(t) {
+    let worker = new Worker('wake-two-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      let rs = e.data[0];
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "ok");
+      assert_equals(rs[2], "timed-out");
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wake-two-from-worker");
+  async_test(function(t) {
+    let worker = new SharedWorker('wake-two-shared-worker.js');
+    worker.port.start();
+    worker.port.onmessage = this.step_func_done(function(e) {
+      let rs = e.data[0];
+      rs.sort();
+      assert_equals(rs[0], "ok");
+      assert_equals(rs[1], "ok");
+      assert_equals(rs[2], "timed-out");
+    });
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wake-two-from-shared-worker");
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let rs = [];
+      let workers = [];
+      let nworkers = 3;
+      // Create two workers and initialize them.
+      for (let i = 0; i < nworkers; i++) {
+        let w = new Worker('wake-two.js');
+        w.onmessage = function(e) {
+          rs.push(e.data);
+        }
+        workers.push(w);
+      }
+      // Send message to all broadcast.
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      for (let i = 0; i < nworkers; i++) {
+        workers[i].postMessage([ia.buffer]);
+      }
+      // Wake one worker.
+      setTimeout(() => assert_equals(2, Atomics.wake(ia, 0, 2)), 500);
+      // Check one worker woke up and another one timed-out.
+      setTimeout(test.step_func_done(function() {
+        rs.sort();
+        assert_equals(rs[0], "ok");
+        assert_equals(rs[1], "ok");
+        assert_equals(rs[2], "timed-out");
+      }), 2000);
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wake-two-from-iframe");
+});
+
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-two/wake-two.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-two/wake-two.js
@@ -1,0 +1,6 @@
+onmessage = function(e) {
+    let sab = e.data[0];
+    let timeout = e.data[1] || 1000;
+    let ia = new Int32Array(sab);
+    postMessage(Atomics.wait(ia, 0, 0, timeout)); // We may timeout eventually
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-zero/wake-zero-popup.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-zero/wake-zero-popup.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes zero waiters if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let popup = window.open("../empty.html", "empty");
+    let test = this;
+    popup.onmessage = function(e) {
+      let worker = new Worker("wake-zero.js");
+      worker.onmessage = test.step_func_done(function(e) {
+        let ret = e.data[0];
+        assert_equals(ret, "timed-out");
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia]);
+      setTimeout(() => assert_equals(0, Atomics.wake(ia, 0, 0)), 500); // Wake zero
+    }
+    popup.postMessage([], "*");
+  }, "atomics-dedicated-worker-wake-zero-from-popup");
+});
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-zero/wake-zero-shared-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-zero/wake-zero-shared-worker.js
@@ -1,0 +1,14 @@
+onconnect = function(e) {
+    let port = e.ports[0];
+
+    port.addEventListener('message', function(e) {
+        let worker = new Worker('wake-zero.js');
+        worker.onmessage = function(e) {
+            port.postMessage([e.data[0]]);
+        }
+        let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+        worker.postMessage([ia]);
+        setTimeout(() => Atomics.wake(ia, 0, 0)); // Wake zero
+    });
+    port.start();
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-zero/wake-zero-worker.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-zero/wake-zero-worker.js
@@ -1,0 +1,10 @@
+onmessage = function() {
+    let worker = new Worker('wake-zero.js');
+    worker.onmessage = function(e) {
+        let ret = e.data[0];
+        postMessage([ret]);
+    }
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia]);
+    setTimeout(() => Atomics.wake(ia, 0, 0)); // Wake zero
+}

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-zero/wake-zero.html
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-zero/wake-zero.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<body>
+    <iframe id="myiframe" style="display: none" src="../empty.html" ></iframe>
+</body>
+
+<script>
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: >
+  Test that Atomics.wake wakes zero waiters if that's what the count is.
+---*/
+
+window.addEventListener("load", function() {
+  async_test(function(t) {
+    let worker = new Worker('wake-zero.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      let ret = e.data[0];
+      assert_equals(ret, "timed-out");
+    });
+    let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    worker.postMessage([ia]);
+    setTimeout(() => assert_equals(0, Atomics.wake(ia, 0, 0)), 500); // Wake zero
+  }, "atomics-dedicated-worker-wake-two");
+  async_test(function(t) {
+    let worker = new Worker('wake-zero-worker.js');
+    worker.onmessage = this.step_func_done(function(e) {
+      let ret = e.data[0];
+      assert_equals(ret, "timed-out");
+    });
+    worker.postMessage([]);
+  }, "atomics-dedicated-worker-wake-zero-from-worker");
+  async_test(function(t) {
+    let worker = new SharedWorker('wake-zero-shared-worker.js');
+    worker.port.onmessage = this.step_func_done(function(e) {
+      let ret = e.data[0];
+      assert_equals(ret, "timed-out");
+    });
+    worker.port.start();
+    worker.port.postMessage([]);
+  }, "atomics-dedicated-worker-wake-zero-from-shared-worker");
+  async_test(function(t) {
+    let iframe = document.getElementById('myiframe');
+    let contentWindow = iframe.contentWindow;
+    let test = this;
+    contentWindow.onmessage = function(e) {
+      let worker = new Worker('wake-zero.js');
+      worker.onmessage = test.step_func_done(function(e) {
+        let ret = e.data[0];
+        assert_equals(ret, "timed-out");
+      });
+      let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+      worker.postMessage([ia]);
+      setTimeout(() => assert_equals(0, Atomics.wake(ia, 0, 0)), 500); // Wake zero
+    }
+    contentWindow.postMessage([], '*');
+  }, "atomics-dedicated-worker-wake-zero-from-iframe");
+});
+</script>

--- a/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-zero/wake-zero.js
+++ b/testing/web-platform/tests/atomics/window-and-any-worker/wake/wake-zero/wake-zero.js
@@ -1,0 +1,5 @@
+onmessage = function(e) {
+    let ia = e.data[0];
+    let ret = Atomics.wait(ia, 0, 0, 1000); // We may timeout eventually.
+    postMessage([ret]);
+}


### PR DESCRIPTION
Fixes #4 and #5.

Reimplement test262's tests that use agent API. Implements version of the tests for Window and DedicatedWorker and any worker and DedicatedWorker.

It's not possible to create a Worker from a ServiceWorker, thus there are not versions of the tests for ServiceWorker. 

Supersedes #1.