### PR TITLE
Import wake/wait tests as web-platform-tests

### DIFF
--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wait/good-views.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wait/good-views.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wait/good-views.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wait
+    description: >
+      Test Atomics.wait on arrays that allow atomic operations,
+      in an Agent that is allowed to wait.
+    ---*/
+    let attrs = {};
+    function test262() {
+      return "" +
+        "let rs = [];\n" +
+        "let A = createWorkerFromString(`\n" +
+        "    onmessage = function(e) {\n" +
+        "      let view = e.data[0];\n" +
+        "      let ret = \"A \" + Atomics.wait(view, 0, 0, 0);\n" +
+        "      postMessage([ret]);\n" +
+        "    }\n" +
+        "    `);\n" +
+        "A.onmessage = function(e) {\n" +
+        "  rs.push(e.data[0]);\n" +
+        "  check_done();\n" +
+        "}\n" +
+        "let B = createWorkerFromString(`\n" +
+        "    onmessage = function(e) {\n" +
+        "      let view = e.data[0];\n" +
+        "      let ret = \"B \" + Atomics.wait(view, 0, 37, 0);\n" +
+        "      postMessage([ret]);\n" +
+        "    }\n" +
+        "    `);\n" +
+        "B.onmessage = function(e) {\n" +
+        "  rs.push(e.data[0]);\n" +
+        "  check_done();\n" +
+        "}\n" +
+        "let C = createWorkerFromString(`\n" +
+        "    onmessage = function(e) {\n" +
+        "      let view = e.data[0];\n" +
+        "      let idx = e.data[1];\n" +
+        "      let ret = \"C \" + Atomics.wait(view, idx, 0);\n" +
+        "      postMessage([ret]);\n" +
+        "    }\n" +
+        "    `);\n" +
+        "C.onmessage = function(e) {\n" +
+        "  rs.push(e.data[0]);\n" +
+        "  check_done();\n" +
+        "}\n" +
+        "function check_done() {\n" +
+        "  if (rs.length == 7) {\n" +
+        "    rs.sort();\n" +
+        "    assert.sameValue(rs[0] == \"A timed-out\", true);\n" +
+        "    assert.sameValue(rs[1] == \"B not-equal\", true);\n" +
+        "    assert.sameValue(rs[2] == \"C not-equal\", true);\n" +
+        "    assert.sameValue(rs[3] == \"C not-equal\", true);\n" +
+        "    assert.sameValue(rs[4] == \"C not-equal\", true);\n" +
+        "    assert.sameValue(rs[5] == \"C not-equal\", true);\n" +
+        "    assert.sameValue(rs[6] == \"C not-equal\", true);\n" +
+        "    exitEventLoop([A, B, C]);\n" +
+        "  }\n" +
+        "}\n" +
+        "let sab = new SharedArrayBuffer(1024);\n" +
+        "let view = new Int32Array(sab, 32, 20);\n" +
+        "A.postMessage([view]);\n" +
+        "B.postMessage([view]);\n" +
+        "let good_indices = [\n" +
+        "  (view) => 0/-1,\n" +
+        "  (view) => '-0',\n" +
+        "  (view) => view.length - 1,\n" +
+        "  (view) => ({ valueOf: () => 0 }),\n" +
+        "  (view) => ({ toString: () => '0', valueOf: false }) // non-callable valueOf triggers invocation of toString\n" +
+        "];\n" +
+        "setTimeout(function() {\n" +
+        "  for (let idxGen of good_indices) {\n" +
+        "    let idx = idxGen(view);\n" +
+        "    view[idx] = 0;\n" +
+        "    // Firefox cannot apply clone algorithm on an Object.\n" +
+        "    // See https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm\n" +
+        "    if (typeof idx == \"object\") {\n" +
+        "      idx = idx.valueOf ? idx.valueOf() : idx.toString();\n" +
+        "    }\n" +
+        "    Atomics.store(view, idx, 37);\n" +
+        "    C.postMessage([view, idx]);\n" +
+        "  }\n" +
+        "}, 500);\n" +
+        "enterEventLoop();\n";
+    }
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame -> Worker (strict): js/test262/built-ins/Atomics/wait/good-views.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame -> Worker: js/test262/built-ins/Atomics/wait/good-views.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window -> Worker (strict): js/test262/built-ins/Atomics/wait/good-views.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window -> Worker: js/test262/built-ins/Atomics/wait/good-views.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker -> Worker (strict): js/test262/built-ins/Atomics/wait/good-views.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker -> Worker: js/test262/built-ins/Atomics/wait/good-views.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker -> Worker (strict): js/test262/built-ins/Atomics/wait/good-views.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker -> Worker: js/test262/built-ins/Atomics/wait/good-views.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wait/nan-timeout.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wait/nan-timeout.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wait/nan-timeout.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wait
+    description: >
+      Test that Atomics.wait does not time out with a NaN timeout
+    ---*/
+    let attrs = {};
+    function test262() {
+      return "" +
+        "let w = createWorkerFromString(`\n" +
+        "    onmessage = function(e) {\n" +
+        "      let ia = e.data[0];\n" +
+        "      let ret = Atomics.wait(ia, 0, 0, NaN); // NaN => Infinity\n" +
+        "      postMessage([ret]);\n" +
+        "    }\n" +
+        "`);\n" +
+        "w.onmessage = function(e) {\n" +
+        "  assert.sameValue(e.data[0], \"ok\");\n" +
+        "  exitEventLoop(w);\n" +
+        "}\n" +
+        "let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));\n" +
+        "w.postMessage([ia]);\n" +
+        "// Ample time\n" +
+        "setTimeout(() => Atomics.wake(ia, 0), 500);\n" +
+        "enterEventLoop();\n";
+    }
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame (strict): js/test262/built-ins/Atomics/wait/nan-timeout.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame: js/test262/built-ins/Atomics/wait/nan-timeout.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window (strict): js/test262/built-ins/Atomics/wait/nan-timeout.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window: js/test262/built-ins/Atomics/wait/nan-timeout.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker (strict): js/test262/built-ins/Atomics/wait/nan-timeout.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker: js/test262/built-ins/Atomics/wait/nan-timeout.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker (strict): js/test262/built-ins/Atomics/wait/nan-timeout.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker: js/test262/built-ins/Atomics/wait/nan-timeout.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wait/negative-timeout.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wait/negative-timeout.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wait/negative-timeout.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wait
+    description: >
+      Test that Atomics.wait times out with a negative timeout
+    ---*/
+    let attrs = {};
+    function test262() {
+      return "" +
+        "let w = createWorkerFromString(`\n" +
+        "    onmessage = function(e) {\n" +
+        "      let ia = new Int32Array(e.data[0]);\n" +
+        "      let then = Date.now();\n" +
+        "      let ret = Atomics.wait(ia, 0, 0, -5);\n" +
+        "      postMessage([ret]);  // -5 => 0\n" +
+        "    }\n" +
+        "`);\n" +
+        "w.onmessage = function(e) {\n" +
+        "  assert.sameValue(e.data[0], \"timed-out\");\n" +
+        "  exitEventLoop(w);\n" +
+        "}\n" +
+        "let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));\n" +
+        "w.postMessage([ia.buffer]);\n" +
+        "enterEventLoop();\n";
+    }
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame (strict): js/test262/built-ins/Atomics/wait/negative-timeout.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame: js/test262/built-ins/Atomics/wait/negative-timeout.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window (strict): js/test262/built-ins/Atomics/wait/negative-timeout.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window: js/test262/built-ins/Atomics/wait/negative-timeout.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker (strict): js/test262/built-ins/Atomics/wait/negative-timeout.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker: js/test262/built-ins/Atomics/wait/negative-timeout.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker (strict): js/test262/built-ins/Atomics/wait/negative-timeout.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker: js/test262/built-ins/Atomics/wait/negative-timeout.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wait/no-spurious-wakeup.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wait/no-spurious-wakeup.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wait/no-spurious-wakeup.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wait
+    description: >
+      Test that Atomics.wait actually waits and does not spuriously wake
+      up when the memory value is changed.
+    includes: [atomicsHelper.js]
+    ---*/
+    let attrs = {"includes": ["atomicsHelper.js"]};
+    function test262() {
+      return "" +
+        "let w = createWorkerFromString(`\n" +
+        "    onmessage = function(e) {\n" +
+        "      let ia = new Int32Array(e.data[0]);\n" +
+        "      let then = Date.now();\n" +
+        "      Atomics.wait(ia, 0, 0);\n" +
+        "      let diff = Date.now() - then; // Should be about 1000 ms but can be more (in fact most times is slightly lower than 1000 ms).\n" +
+        "      postMessage([diff]);\n" +
+        "    }\n" +
+        "`);\n" +
+        "w.onmessage = function(e) {\n" +
+        "  assert.sameValue(e.data[0] >= 900, true);\n" +
+        "  exitEventLoop(w);\n" +
+        "}\n" +
+        "let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));\n" +
+        "w.postMessage([ia.buffer]);\n" +
+        "setTimeout(function() {      // Give the agent a chance to wait\n" +
+        "  Atomics.store(ia, 0, 1);        // Change the value, should not wake the agent\n" +
+        "  setTimeout(function() {              // Wait some more so that we can tell\n" +
+        "    Atomics.wake(ia, 0);          // Really wake it up\n" +
+        "  }, 500);\n" +
+        "}, 500);\n" +
+        "enterEventLoop();\n";
+    }
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame (strict): js/test262/built-ins/Atomics/wait/no-spurious-wakeup.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame: js/test262/built-ins/Atomics/wait/no-spurious-wakeup.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window (strict): js/test262/built-ins/Atomics/wait/no-spurious-wakeup.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window: js/test262/built-ins/Atomics/wait/no-spurious-wakeup.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker (strict): js/test262/built-ins/Atomics/wait/no-spurious-wakeup.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker: js/test262/built-ins/Atomics/wait/no-spurious-wakeup.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker (strict): js/test262/built-ins/Atomics/wait/no-spurious-wakeup.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker: js/test262/built-ins/Atomics/wait/no-spurious-wakeup.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wait/was-woken.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wait/was-woken.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wait/was-woken.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wait
+    description: >
+      Test that Atomics.wait returns the right result when it was awoken.
+    ---*/
+    let attrs = {};
+    function test262() {
+      return "" +
+        "let w = createWorkerFromString(`\n" +
+        "    onmessage = function(e) {\n" +
+        "      let ia = new Int32Array(e.data[0]);\n" +
+        "      let ret = Atomics.wait(ia, 0, 0); // No timeout => Infinity\n" +
+        "      postMessage([ret]);\n" +
+        "    }\n" +
+        "`);\n" +
+        "w.onmessage = function(e) {\n" +
+        "  assert.sameValue(e.data[0], \"ok\");\n" +
+        "  exitEventLoop(w);\n" +
+        "}\n" +
+        "let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));\n" +
+        "w.postMessage([ia.buffer]);\n" +
+        "// Give the agent a chance to wait.\n" +
+        "setTimeout(() => Atomics.wake(ia, 0), 500);\n" +
+        "enterEventLoop();\n";
+    }
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame (strict): js/test262/built-ins/Atomics/wait/was-woken.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame: js/test262/built-ins/Atomics/wait/was-woken.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window (strict): js/test262/built-ins/Atomics/wait/was-woken.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window: js/test262/built-ins/Atomics/wait/was-woken.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker (strict): js/test262/built-ins/Atomics/wait/was-woken.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker: js/test262/built-ins/Atomics/wait/was-woken.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker (strict): js/test262/built-ins/Atomics/wait/was-woken.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker: js/test262/built-ins/Atomics/wait/was-woken.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-all-on-loc.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-all-on-loc.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wake/wake-all-on-loc.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wake
+    description: >
+      Test that Atomics.wake wakes all waiters on a location, but does not
+      wake waiters on other locations.
+    ---*/
+    let attrs = {};
+    function test262() {
+			return "" +
+				"var WAKEUP = 0;                 // Waiters on this will be woken\n" +
+				"var DUMMY = 1;                  // Waiters on this will not be woken\n" +
+				"var RUNNING = 2;                // Accounting of live agents\n" +
+				"var NUMELEM = 3;\n" +
+				"var NUMAGENT = 3;\n" +
+				"let rs = [];\n" +
+				"let ws = [];\n" +
+				"for (var i=0; i < NUMAGENT; i++) {\n" +
+				"	let w = createWorkerFromString(`\n" +
+				"			onmessage = function(e) {\n" +
+				"				var ia = new Int32Array(e.data[0]);\n" +
+				"				Atomics.add(ia, ${RUNNING}, 1);\n" +
+				"				let ret = \"A \" + Atomics.wait(ia, ${WAKEUP}, 0);\n" +
+				"				postMessage(ret);\n" +
+				"			}\n" +
+				"  `);\n" +
+				"  w.onmessage = function(e) {\n" +
+				"    rs.push(e.data);\n" +
+				"    check_results();\n" +
+				"  };\n" +
+				"  ws.push(w);\n" +
+				"}\n" +
+				"let w = createWorkerFromString(`\n" +
+				"  onmessage = function(e) {\n" +
+				"			var ia = new Int32Array(e.data[0]);\n" +
+				"			Atomics.add(ia, ${RUNNING}, 1);\n" +
+				"			// This will always time out.\n" +
+				"			let ret = \"B \" + Atomics.wait(ia, ${DUMMY}, 0, 1000);\n" +
+				"			postMessage(ret);\n" +
+				"  }\n" +
+				"`);\n" +
+				"w.onmessage = function(e) {\n" +
+				"  rs.push(e.data);\n" +
+				"  check_results();\n" +
+				"}\n" +
+				"ws.push(w);\n" +
+				"var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELEMENT));\n" +
+				"ws.forEach(function(worker) {\n" +
+				"  worker.postMessage([ia.buffer]);\n" +
+				"});\n" +
+				"setTimeout(function() {\n" +
+				"  // Wait for agents to be running.\n" +
+				"  waitUntil(ia, RUNNING, NUMAGENT+1);\n" +
+				"  // Then wait some more to give the agents a fair chance to wait.  If we don't,\n" +
+				"  // we risk sending the wakeup before agents are sleeping, and we hang.\n" +
+				"  sleep(500).then(function() {\n" +
+				"    // Wake all waiting on WAKEUP, should be 3 always, they won't time out.\n" +
+				"    assert.sameValue(Atomics.wake(ia, WAKEUP), NUMAGENT);\n" +
+				"  });\n" +
+				"}, 500);\n" +
+				"function check_results() {\n" +
+				"  if (rs.length == NUMAGENT+1) {\n" +
+				"    rs.sort();\n" +
+				"    for (var i=0; i < NUMAGENT; i++)\n" +
+				"      assert.sameValue(rs[i], \"A ok\");\n" +
+				"    assert.sameValue(rs[NUMAGENT], \"B timed-out\");\n" +
+				"    exitEventLoop(ws);\n" +
+				"  }\n" +
+				"}\n" +
+				"function waitUntil(ia, k, value) {\n" +
+				"	var i = 0;\n" +
+				"	while (Atomics.load(ia, k) !== value && i < 15) {\n" +
+				"		sleep(100);\n" +
+				"		i++;\n" +
+				"	}\n" +
+				"	assert.sameValue(Atomics.load(ia, k), value, \"All agents are running\");\n" +
+				"}\n";
+    }
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame (strict): js/test262/built-ins/Atomics/wake/wake-all-on-loc.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame: js/test262/built-ins/Atomics/wake/wake-all-on-loc.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window (strict): js/test262/built-ins/Atomics/wake/wake-all-on-loc.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window: js/test262/built-ins/Atomics/wake/wake-all-on-loc.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker (strict): js/test262/built-ins/Atomics/wake/wake-all-on-loc.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker: js/test262/built-ins/Atomics/wake/wake-all-on-loc.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker (strict): js/test262/built-ins/Atomics/wake/wake-all-on-loc.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker: js/test262/built-ins/Atomics/wake/wake-all-on-loc.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-all.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-all.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wake/wake-all.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wake
+    description: >
+      Test that Atomics.wake wakes all waiters if that's what the count is.
+    ---*/
+    let attrs = {};
+    function test262() {
+			return "" +
+				"var WAKEUP = 0;                 // Waiters on this will be woken\n" +
+				"var DUMMY = 1;                  // Waiters on this will not be woken\n" +
+				"var RUNNING = 2;                // Accounting of live agents\n" +
+				"var NUMELEM = 3;\n" +
+				"var NUMAGENT = 3;\n" +
+				"let rs = [];\n" +
+				"let ws = [];\n" +
+				"for (var i=0; i < NUMAGENT; i++) {\n" +
+				"	let w = createWorkerFromString(`\n" +
+				"			onmessage = function(e) {\n" +
+				"				var ia = new Int32Array(e.data[0]);\n" +
+				"				Atomics.add(ia, ${RUNNING}, 1);\n" +
+				"				let ret = \"A \" + Atomics.wait(ia, ${WAKEUP}, 0);\n" +
+				"				postMessage(ret);\n" +
+				"			}\n" +
+				"  `);\n" +
+				"  w.onmessage = function(e) {\n" +
+				"    rs.push(e.data);\n" +
+				"    check_results();\n" +
+				"  };\n" +
+				"  ws.push(w);\n" +
+				"}\n" +
+				"let w = createWorkerFromString(`\n" +
+				"  onmessage = function(e) {\n" +
+				"			var ia = new Int32Array(e.data[0]);\n" +
+				"			Atomics.add(ia, ${RUNNING}, 1);\n" +
+				"			// This will always time out.\n" +
+				"			let ret = \"B \" + Atomics.wait(ia, ${DUMMY}, 0, 1000);\n" +
+				"			postMessage(ret);\n" +
+				"  }\n" +
+				"`);\n" +
+				"w.onmessage = function(e) {\n" +
+				"  rs.push(e.data);\n" +
+				"  check_results();\n" +
+				"}\n" +
+				"ws.push(w);\n" +
+				"var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELEMENT));\n" +
+				"ws.forEach(function(worker) {\n" +
+				"  worker.postMessage([ia.buffer]);\n" +
+				"});\n" +
+				"setTimeout(function() {\n" +
+				"  // Wait for agents to be running.\n" +
+				"  waitUntil(ia, RUNNING, NUMAGENT+1);\n" +
+				"  // Then wait some more to give the agents a fair chance to wait.  If we don't,\n" +
+				"  // we risk sending the wakeup before agents are sleeping, and we hang.\n" +
+				"  sleep(500).then(function() {\n" +
+				"    // Wake all waiting on WAKEUP, should be 3 always, they won't time out.\n" +
+				"    assert.sameValue(Atomics.wake(ia, WAKEUP), NUMAGENT);\n" +
+				"  });\n" +
+				"}, 500);\n" +
+				"function check_results() {\n" +
+				"  if (rs.length == NUMAGENT+1) {\n" +
+				"    rs.sort();\n" +
+				"    for (var i=0; i < NUMAGENT; i++)\n" +
+				"      assert.sameValue(rs[i], \"A ok\");\n" +
+				"    assert.sameValue(rs[NUMAGENT], \"B timed-out\");\n" +
+				"    exitEventLoop(ws);\n" +
+				"  }\n" +
+				"}\n" +
+				"function waitUntil(ia, k, value) {\n" +
+				"	var i = 0;\n" +
+				"	while (Atomics.load(ia, k) !== value && i < 15) {\n" +
+				"		sleep(100);\n" +
+				"		i++;\n" +
+				"	}\n" +
+				"	assert.sameValue(Atomics.load(ia, k), value, \"All agents are running\");\n" +
+				"}\n";
+    }
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame (strict): js/test262/built-ins/Atomics/wake/wake-all.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame: js/test262/built-ins/Atomics/wake/wake-all.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window (strict): js/test262/built-ins/Atomics/wake/wake-all.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window: js/test262/built-ins/Atomics/wake/wake-all.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker (strict): js/test262/built-ins/Atomics/wake/wake-all.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker: js/test262/built-ins/Atomics/wake/wake-all.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker (strict): js/test262/built-ins/Atomics/wake/wake-all.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker: js/test262/built-ins/Atomics/wake/wake-all.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-in-order.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-in-order.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wake/wake-in-order.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wake
+    description: >
+      Test that Atomics.wake wakes agents in the order they are waiting.
+    ---*/
+    let attrs = {};
+    function test262() {
+		return "" +
+      "let NUMAGENT = 3;\n" +
+			"\n" +
+			"let WAKEUP = 0;                 // Waiters on this will be woken\n" +
+			"let SPIN = 1;                   // Worker i (zero-based) spins on location SPIN+i\n" +
+			"let RUNNING = SPIN + NUMAGENT;  // Accounting of live agents\n" +
+			"let NUMELEM = RUNNING + 1;\n" +
+			"\n" +
+			"// Create workers and start them all spinning.  We set atomic slots to make\n" +
+			"// them go into a wait, thus controlling the waiting order.  Then we wake them\n" +
+			"// one by one and observe the wakeup order.\n" +
+			"\n" +
+			"let rs = [];\n" +
+			"let ws = [];\n" +
+			"for (let i=0 ; i < NUMAGENT ; i++) {\n" +
+			"	let w = createWorkerFromString(`\n" +
+			"			onmessage = function(e) {\n" +
+			"				let sab = e.data[0];    \n" +
+			"				let ia = new Int32Array(sab);\n" +
+			"				Atomics.add(ia, ${RUNNING}, 1);\n" +
+			"				while (Atomics.load(ia, ${SPIN + i}) === 0)\n" +
+			"					/* nothing */ ;\n" +
+			"				var ret = ${i} + Atomics.wait(ia, ${WAKEUP}, 0);\n" +
+			"				postMessage([ret]);\n" +
+			"			}\n" +
+			"	`);\n" +
+			"	w.onmessage = function(e) {\n" +
+			"		rs.push(e.data[0]);\n" +
+			"		check_results();\n" +
+			"	}\n" +
+			"	ws.push(w);\n" +
+			"}\n" +
+			"\n" +
+			"let ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELEMENT));\n" +
+			"ws.forEach((w) => w.postMessage([ia.buffer]));\n" +
+			"\n" +
+			"setTimeout(function() {\n" +
+			"	// Wait for agents to be running.\n" +
+			"	waitUntil(ia, RUNNING, NUMAGENT);\n" +
+			"\n" +
+			"	// Then wait some more to give the agents a fair chance to wait.  If we don't,\n" +
+			"	// we risk sending the wakeup before agents are sleeping, and we hang.\n" +
+			"	sleep(500).then(function() {\n" +
+			"		for (let i=0; i < NUMAGENT; i++) {\n" +
+			"			sleep(500).then(() => Atomics.store(ia, SPIN+i, 1));\n" +
+			"		}\n" +
+			"	});\n" +
+			"\n" +
+			"	// Wake them up one at a time and check the order is 0 1 2\n" +
+			"	for (let i=0; i < NUMAGENT; i++) {\n" +
+			"		sleep(200).then(() => assert.sameValue(Atomics.wake(ia, WAKEUP, 1), 1));\n" +
+			"	}\n" +
+			"\n" +
+			"	enterEventLoop();\n" +
+			"}, 500);\n" +
+			"\n" +
+			"function check_results() {\n" +
+			"	if (rs.length == NUMAGENT) {\n" +
+			"		for (let i = 0; i < NUMAGENT; i++) {\n" +
+			"			assert.sameValue(rs[i], i + \"ok\");\n" +
+			"		}\n" +
+			"		exitEventLoop(ws);\n" +
+			"	}\n" +
+			"}\n" +
+			"\n" +
+			"function waitUntil(ia, k, value) {\n" +
+			"	let i = 0;\n" +
+			"	while (Atomics.load(ia, k) !== value && i < 15) {\n" +
+			"		sleep(100);\n" +
+			"		i++;\n" +
+			"	}\n" +
+			"	assert.sameValue(Atomics.load(ia, k), value, \"All agents are running\");\n" +
+			"}\n";
+    }
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame (strict): js/test262/built-ins/Atomics/wake/wake-in-order.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame: js/test262/built-ins/Atomics/wake/wake-in-order.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window (strict): js/test262/built-ins/Atomics/wake/wake-in-order.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window: js/test262/built-ins/Atomics/wake/wake-in-order.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker (strict): js/test262/built-ins/Atomics/wake/wake-in-order.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker: js/test262/built-ins/Atomics/wake/wake-in-order.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker (strict): js/test262/built-ins/Atomics/wake/wake-in-order.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker: js/test262/built-ins/Atomics/wake/wake-in-order.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-nan.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-nan.html
@@ -1,0 +1,67 @@
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>test262/test/built-ins/Atomics/wake/wake-nan.html</title>
+    <meta name="help" href="https://storage.spec.whatwg.org/#dom-storagemanager-persisted">
+    <meta name="author" title="Mozilla" href="https://www.mozilla.org">
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+
+    <!-- Test262 harness -->
+    <script src="/resources/test262-harness.js"></script>
+
+    <!-- Test262 required libraries -->
+    <script src="/test262/harness/assert.js"></script>
+    <script src="/test262/harness/sta.js"></script>
+
+    <!-- Per-test required libraries -->
+
+
+  </head>
+  <body></body>
+  <script type="text/javascript">
+    window.addEventListener('load', function(e) {
+
+// Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-atomics.wake
+description: >
+  Test that Atomics.wake wakes zero waiters if the count is NaN
+---*/
+function test262_in_window() {
+   $262.agent.start(
+   `
+   $262.agent.receiveBroadcast(function (sab) {
+     var ia = new Int32Array(sab);
+     $262.agent.report(Atomics.wait(ia, 0, 0, 1000)); // We will timeout eventually
+     $262.agent.leaving();
+   })
+   `);
+
+   var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+
+   $262.agent.broadcast(ia.buffer);
+   $262.agent.sleep(500);                             // Give the agent a chance to wait
+   assert.sameValue(Atomics.wake(ia, 0, NaN), 0);  // Don't actually wake it
+   assert.sameValue(getReport(), "timed-out");
+
+   function getReport() {
+       var r;
+       while ((r = $262.agent.getReport()) == null)
+           $262.agent.sleep(100);
+       return r;
+   }
+
+}
+test(function() {
+   test262_in_window();
+}, 'test262/test/built-ins/Atomics/wake/wake-nan.html');
+
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-negative.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-negative.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wake/wake-negative.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wake
+    description: >
+      Test that Atomics.wake wakes zero waiters if the count is negative
+    ---*/
+    let attrs = {};
+    function test262() {
+			return "" +
+				"let w = createWorkerFromString(`\n" +
+				"    onmessage = function(e) {\n" +
+				"      let ia = new Int32Array(e.data[0]);\n" +
+				"      let ret = Atomics.wait(ia, 0, 0, 1000); // We will timeout eventually\n" +
+				"      postMessage([ret]);\n" +
+				"    }\n" +
+				"`);\n" +
+				"w.onmessage = function(e) {\n" +
+				"  assert.sameValue(e.data[0], \"timed-out\");\n" +
+				"  exitEventLoop(w);\n" +
+				"}\n" +
+				"let ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));\n" +
+				"w.postMessage([ia.buffer]);\n" +
+				"sleep(500).then(() => // Give the agent a chance to wait\n" +
+				"    assert.sameValue(Atomics.wake(ia, 0, -1), 0)); // Don't actually wake it\n" +
+				"enterEventLoop();\n";
+    }
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame (strict): js/test262/built-ins/Atomics/wake/wake-negative.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame: js/test262/built-ins/Atomics/wake/wake-negative.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window (strict): js/test262/built-ins/Atomics/wake/wake-negative.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window: js/test262/built-ins/Atomics/wake/wake-negative.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker (strict): js/test262/built-ins/Atomics/wake/wake-negative.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker: js/test262/built-ins/Atomics/wake/wake-negative.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker (strict): js/test262/built-ins/Atomics/wake/wake-negative.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker: js/test262/built-ins/Atomics/wake/wake-negative.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-one.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-one.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wake/wake-one.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wake
+    description: >
+      Test that Atomics.wake wakes one waiter if that's what the count is.
+    ---*/
+    let attrs = {};
+    function test262() {
+			return "" +
+				"let NUMAGENT = 3;\n" +
+				"let WAKEUP = 0;     // Agents wait here\n" +
+				"let RUNNING = 1;    // Accounting of live agents here\n" +
+				"let NUMELEM = 2;\n" +
+				"let WAKECOUNT = 1;\n" +
+				"let rs = [];\n" +
+				"let ws = [];\n" +
+				"for (let i = 0; i < NUMAGENT; i++) {\n" +
+				"  let w = createWorkerFromString(`\n" +
+				"      onmessage = function(e) {\n" +
+				"        let ia = new Int32Array(e.data[0]);\n" +
+				"        Atomics.add(ia, ${RUNNING}, 1);\n" +
+				"        // Waiters that are not woken will time out eventually.\n" +
+				"        let ret = Atomics.wait(ia, ${WAKEUP}, 0, 3000);\n" +
+				"        postMessage(ret);\n" +
+				"      }\n" +
+				"  `);\n" +
+				"  w.onmessage = function(e) {\n" +
+				"    rs.push(e.data);\n" +
+				"    check_results();\n" +
+				"  }\n" +
+				"  ws.push(w);\n" +
+				"}\n" +
+				"var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELEMENT));\n" +
+				"ws.forEach(function(w) {\n" +
+				"  w.postMessage([ia.buffer]);\n" +
+				"});\n" +
+				"setTimeout(function() {\n" +
+				"  // Wait for agents to be running.\n" +
+				"  waitUntil(ia, RUNNING, NUMAGENT);\n" +
+				"  enterEventLoop();\n" +
+				"  // Then wait some more to give the agents a fair chance to wait.  If we don't,\n" +
+				"  // we risk sending the wakeup before agents are sleeping, and we hang.\n" +
+				"  sleep(500).then(function() {\n" +
+				"    // There's a slight risk we'll fail to wake the desired count, if the preceding\n" +
+				"    // sleep() took much longer than anticipated and workers have started timing\n" +
+				"    // out.\n" +
+				"    assert.sameValue(Atomics.wake(ia, 0, WAKECOUNT), WAKECOUNT);\n" +
+				"  });\n" +
+				"}, 500);\n" +
+				"function check_results() {\n" +
+				"  if (rs.length == NUMAGENT) {\n" +
+				"    rs.sort();\n" +
+				"    for (let i=0; i < WAKECOUNT; i++)\n" +
+				"      assert.sameValue(rs[i], \"ok\");\n" +
+				"    for (let i=WAKECOUNT; i < NUMAGENT; i++)\n" +
+				"      assert.sameValue(rs[i], \"timed-out\");\n" +
+				"    exitEventLoop(ws);\n" +
+				"  }\n" +
+				"}\n" +
+				"function waitUntil(ia, k, value) {\n" +
+				"  var i = 0;\n" +
+				"  while (Atomics.load(ia, k) !== value && i < 15) {\n" +
+				"    sleep(300);\n" +
+				"    i++;\n" +
+				"  }\n" +
+				"  assert.sameValue(Atomics.load(ia, k), value, \"All agents are running\");\n" +
+				"}\n";
+    }
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame (strict): js/test262/built-ins/Atomics/wake/wake-one.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame: js/test262/built-ins/Atomics/wake/wake-one.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window (strict): js/test262/built-ins/Atomics/wake/wake-one.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window: js/test262/built-ins/Atomics/wake/wake-one.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker (strict): js/test262/built-ins/Atomics/wake/wake-one.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker: js/test262/built-ins/Atomics/wake/wake-one.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker (strict): js/test262/built-ins/Atomics/wake/wake-one.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker: js/test262/built-ins/Atomics/wake/wake-one.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-two.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-two.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wake/wake-two.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wake
+    description: >
+      Test that Atomics.wake wakes two waiters if that's what the count is.
+    ---*/
+    let attrs = {};
+    function test262() {
+			return "" +
+				"var NUMAGENT = 3;\n" +
+				"var WAKEUP = 0;                 // Agents wait here\n" +
+				"var RUNNING = 1;                // Accounting of live agents here\n" +
+				"var NUMELEM = 2;\n" +
+				"var WAKECOUNT = 2;\n" +
+				"let rs = [];\n" +
+				"let ws = [];\n" +
+				"for (let i = 0; i < NUMAGENT; i++) {\n" +
+				"  let w = createWorkerFromString(`\n" +
+				"      onmessage = function(e) {\n" +
+				"        let ia = new Int32Array(e.data[0]);\n" +
+				"        Atomics.add(ia, ${RUNNING}, 1);\n" +
+				"        // Waiters that are not woken will time out eventually.\n" +
+				"        let ret = Atomics.wait(ia, ${WAKEUP}, 0, 3000);\n" +
+				"        postMessage(ret);\n" +
+				"      }\n" +
+				"  `);\n" +
+				"  w.onmessage = function(e) {\n" +
+				"    rs.push(e.data);\n" +
+				"    check_results();\n" +
+				"  }\n" +
+				"  ws.push(w);\n" +
+				"}\n" +
+				"var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELEMENT));\n" +
+				"ws.forEach(function(w) {\n" +
+				"  w.postMessage([ia.buffer]);\n" +
+				"});\n" +
+				"setTimeout(function() {\n" +
+				"  // Wait for agents to be running.\n" +
+				"  waitUntil(ia, RUNNING, NUMAGENT);\n" +
+				"  enterEventLoop();\n" +
+				"  // Then wait some more to give the agents a fair chance to wait.  If we don't,\n" +
+				"  // we risk sending the wakeup before agents are sleeping, and we hang.\n" +
+				"  sleep(500).then(function() {\n" +
+				"    // There's a slight risk we'll fail to wake the desired count, if the preceding\n" +
+				"    // sleep() took much longer than anticipated and workers have started timing\n" +
+				"    // out.\n" +
+				"    assert.sameValue(Atomics.wake(ia, 0, WAKECOUNT), WAKECOUNT);\n" +
+				"  });\n" +
+				"}, 500);\n" +
+				"function check_results() {\n" +
+				"  if (rs.length == NUMAGENT) {\n" +
+				"    rs.sort();\n" +
+				"    for (let i=0; i < WAKECOUNT; i++)\n" +
+				"      assert.sameValue(rs[i], \"ok\");\n" +
+				"    for (let i=WAKECOUNT; i < NUMAGENT; i++)\n" +
+				"      assert.sameValue(rs[i], \"timed-out\");\n" +
+				"    exitEventLoop(ws);\n" +
+				"  }\n" +
+				"}\n" +
+				"function waitUntil(ia, k, value) {\n" +
+				"  var i = 0;\n" +
+				"  while (Atomics.load(ia, k) !== value && i < 15) {\n" +
+				"    sleep(300);\n" +
+				"    i++;\n" +
+				"  }\n" +
+				"  assert.sameValue(Atomics.load(ia, k), value, \"All agents are running\");\n" +
+				"}\n";
+    }
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame (strict): js/test262/built-ins/Atomics/wake/wake-two.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame: js/test262/built-ins/Atomics/wake/wake-two.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window (strict): js/test262/built-ins/Atomics/wake/wake-two.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window: js/test262/built-ins/Atomics/wake/wake-two.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker (strict): js/test262/built-ins/Atomics/wake/wake-two.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker: js/test262/built-ins/Atomics/wake/wake-two.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker (strict): js/test262/built-ins/Atomics/wake/wake-two.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker: js/test262/built-ins/Atomics/wake/wake-two.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-zero.html
+++ b/testing/web-platform/tests/js/test262/test/built-ins/Atomics/wake/wake-zero.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>js/test262/built-ins/Atomics/wake/wake-zero.html</title>
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-worker-harness.js?pipe=sub"></script>
+    <script src="/resources/test262-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+    // Copyright (C) 2017 Mozilla Corporation.  All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+
+    /*---
+    esid: sec-atomics.wake
+    description: >
+      Test that Atomics.wake wakes zero waiters if that's what the count is.
+    ---*/
+    let attrs = {};
+    function test262() {
+			return "" +
+				"let NUMAGENT = 3;\n" +
+				"let WAKEUP = 0;     // Agents wait here\n" +
+				"let RUNNING = 1;    // Accounting of live agents here\n" +
+				"let NUMELEM = 2;\n" +
+				"let WAKECOUNT = 0;\n" +
+				"let rs = [];\n" +
+				"let ws = [];\n" +
+				"for (let i = 0; i < NUMAGENT; i++) {\n" +
+				"  let w = createWorkerFromString(`\n" +
+				"      onmessage = function(e) {\n" +
+				"        let ia = new Int32Array(e.data[0]);\n" +
+				"        Atomics.add(ia, ${RUNNING}, 1);\n" +
+				"        // Waiters that are not woken will time out eventually.\n" +
+				"        let ret = Atomics.wait(ia, ${WAKEUP}, 0, 2000);\n" +
+				"        postMessage(ret);\n" +
+				"      }\n" +
+				"  `);\n" +
+				"  w.onmessage = function(e) {\n" +
+				"    rs.push(e.data);\n" +
+				"    check_results();\n" +
+				"  }\n" +
+				"  ws.push(w);\n" +
+				"}\n" +
+				"var ia = new Int32Array(new SharedArrayBuffer(NUMELEM * Int32Array.BYTES_PER_ELEMENT));\n" +
+				"ws.forEach(function(w) {\n" +
+				"  w.postMessage([ia.buffer]);\n" +
+				"});\n" +
+				"setTimeout(function() {\n" +
+				"  // Wait for agents to be running.\n" +
+				"  waitUntil(ia, RUNNING, NUMAGENT);\n" +
+				"  enterEventLoop();\n" +
+				"  // Then wait some more to give the agents a fair chance to wait.  If we don't,\n" +
+				"  // we risk sending the wakeup before agents are sleeping, and we hang.\n" +
+				"  sleep(500).then(function() {\n" +
+				"    // There's a slight risk we'll fail to wake the desired count, if the preceding\n" +
+				"    // sleep() took much longer than anticipated and workers have started timing\n" +
+				"    // out.\n" +
+				"    assert.sameValue(Atomics.wake(ia, 0, WAKECOUNT), WAKECOUNT);\n" +
+				"  });\n" +
+				"}, 500);\n" +
+				"function check_results() {\n" +
+				"  if (rs.length == NUMAGENT) {\n" +
+				"    rs.sort();\n" +
+				"    for (let i=0; i < WAKECOUNT; i++)\n" +
+				"      assert.sameValue(rs[i], \"ok\");\n" +
+				"    for (let i=WAKECOUNT; i < NUMAGENT; i++)\n" +
+				"      assert.sameValue(rs[i], \"timed-out\");\n" +
+				"    exitEventLoop(ws);\n" +
+				"  }\n" +
+				"}\n" +
+				"function waitUntil(ia, k, value) {\n" +
+				"  var i = 0;\n" +
+				"  while (Atomics.load(ia, k) !== value && i < 15) {\n" +
+				"    sleep(300);\n" +
+				"    i++;\n" +
+				"  }\n" +
+				"  assert.sameValue(Atomics.load(ia, k), value, \"All agents are running\");\n" +
+				"}\n";
+						}
+    window.addEventListener('load', function(e) {
+      async_test(function(t) {
+        run_in_iframe_strict(test262, attrs, t);
+      }, 'IFrame (strict): js/test262/built-ins/Atomics/wake/wake-zero.html');
+      async_test(function(t) {
+        run_in_iframe(test262, attrs, t);
+      }, 'IFrame: js/test262/built-ins/Atomics/wake/wake-zero.html');
+      async_test(function(t) {
+        run_in_window_strict(test262, attrs, t);
+      }, 'Window (strict): js/test262/built-ins/Atomics/wake/wake-zero.html');
+      async_test(function(t) {
+        run_in_window(test262, attrs, t);
+      }, 'Window: js/test262/built-ins/Atomics/wake/wake-zero.html');
+      async_test(function(t) {
+        run_in_worker_strict(test262, attrs, t);
+      }, 'Worker (strict): js/test262/built-ins/Atomics/wake/wake-zero.html');
+      async_test(function(t) {
+        run_in_worker(test262, attrs, t);
+      }, 'Worker: js/test262/built-ins/Atomics/wake/wake-zero.html');
+      async_test(function(t) {
+        run_in_shared_worker_strict(test262, attrs, t);
+      }, 'SharedWorker (strict): js/test262/built-ins/Atomics/wake/wake-zero.html');
+      async_test(function(t) {
+        run_in_shared_worker(test262, attrs, t);
+      }, 'SharedWorker: js/test262/built-ins/Atomics/wake/wake-zero.html');
+    });
+  </script>
+</html>

--- a/testing/web-platform/tests/resources/test262-worker-harness.js
+++ b/testing/web-platform/tests/resources/test262-worker-harness.js
@@ -1,0 +1,307 @@
+let HTML_TEMPLATE = `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title></title>
+        <!-- Test262 required libraries -->
+        <script src="http://{{host}}:{{ports[http][0]}}/resources/test262/harness/assert.js"><\/script>
+        <script src="http://{{host}}:{{ports[http][0]}}/resources/test262/harness/sta.js"><\/script>
+        <script type="text/javascript">
+            function createWorkerFromString(source_text) {
+                let blob = new Blob([source_text], {type: 'text/javascript'});
+                let url = URL.createObjectURL(blob);
+                return new Worker(url);
+            }
+
+            function enterEventLoop() {}
+
+            function exitEventLoop(w) {
+                if (w.constructor === Array) {
+                    w.forEach((w) => w.terminate());
+                } else if (typeof w === 'object') {
+                    w.terminate();
+                }
+                dispatchEvent(new CustomEvent('done'));
+            }
+
+            function sleep(ns) {
+                function wait(sec) {
+                    let start = Date.now();
+                    while (true) {
+                        if (Date.now() - start > sec) {
+                            return;
+                        }
+                    }
+                }
+                wait(ns);
+                return {
+                    then: function(fn) {
+                        if (fn) { fn(); }
+                    }
+                }
+            }
+        <\/script>
+    </head>
+    <body>
+
+    </body>
+
+    <script type="text/javascript">
+        window.addEventListener('load', function() {
+            ###TEST262###
+        });
+    <\/script>
+    </html>
+`;
+
+function prepareTest(test262, opts) {
+    let output = [];
+    if (opts.strict) {
+        output.push('"use strict;"');
+    }
+    output.push(test262());
+    return output.join("\n");
+}
+
+// Run in iframe strict.
+function run_in_iframe_strict(test262, attrs, t) {
+    run_in_iframe(test262, attrs, t, {strict: true});
+}
+
+// Run in iframe.
+function run_in_iframe(test262, attrs, t, opts) {
+    opts = opts || {};
+    let html = HTML_TEMPLATE.replace('###TEST262###', prepareTest(test262, opts));
+    console.log(html);
+
+    let blob = new Blob([html], {type: 'text/html'});
+    let iframe = document.createElement('iframe');
+    iframe.style = 'display: none';
+    iframe.src = URL.createObjectURL(blob);
+    document.body.appendChild(iframe);
+
+    let contentWindow = iframe.contentWindow;
+    contentWindow.addEventListener('done', t.step_func(function(e) {
+        t.done();
+    }));
+    let FAILED = 'iframe-failed' + opts.strict ? "-strict" : "";
+    contentWindow.addEventListener('error', function(e) {
+        e.preventDefault();
+        top.dispatchEvent(new CustomEvent(FAILED, {detail: e.message}));
+    });
+    window.addEventListener(FAILED, t.step_func(function(e) {
+        t.set_status(t.FAIL);
+        throw new Error(e.detail);
+    }));
+}
+
+// Run in window strict.
+function run_in_window_strict(test262, attrs, t) {
+    run_in_window(test262, attrs, t, {strict: true});
+}
+
+// Run in window.
+function run_in_window(test262, attrs, t, opts) {
+    opts = opts || {};
+    let html = HTML_TEMPLATE.replace('###TEST262###', prepareTest(test262, opts));
+
+    let blob = new Blob([html], {type: 'text/html'});
+    let url = URL.createObjectURL(blob);
+
+    let popup = window.open(url, 'popup');
+    popup.addEventListener('done', t.step_func(function(e) {
+        popup.close();
+        t.done();
+    }));
+
+    let FAILED = 'popup-failed' + opts.strict ? "-strict" : "";
+    popup.addEventListener('error', function(e) {
+        e.preventDefault();
+        top.dispatchEvent(new CustomEvent(FAILED, {detail: e.message}));
+    });
+    window.addEventListener(FAILED, t.step_func(function(e) {
+        t.set_status(t.FAIL);
+        throw new Error(e.detail);
+    }));
+}
+
+let WORKER_TEMPLATE = `
+    ###INCLUDES###
+
+    function createWorkerFromString(source_text) {
+        let blob = new Blob([source_text], {type: 'text/javascript'});
+        let url = URL.createObjectURL(blob);
+        return new Worker(url);
+    }
+
+    function enterEventLoop() {}
+
+    function exitEventLoop(w) {
+        if (w.constructor === Array) {
+            w.forEach((w) => w.terminate());
+        } else if (typeof w === 'object') {
+            w.terminate();
+        }
+        postMessage(['done']);
+    }
+
+    function sleep(ns) {
+        function wait(sec) {
+            let start = Date.now();
+            while (true) {
+                if (Date.now() - start > sec) {
+                    return;
+                }
+            }
+        }
+        wait(ns);
+        return {
+            then: function(fn) {
+                if (fn) { fn(); }
+            }
+        }
+    }
+
+    onmessage = function(e) {
+        ###TEST262###
+    }
+`;
+
+function importScripts(includes) {
+    function quote(str) {
+        return "'" + str + "'";
+    }
+    includes = includes || [];
+    let output = [];
+    let root = 'http://{{host}}:{{ports[http][0]}}/resources/test262/harness/';
+    let mandatory = ['assert.js', 'sta.js'];
+    mandatory.forEach(function(filename) {
+        output.push(quote(root + filename));
+    });
+    includes.forEach(function(filename) {
+        output.push(quote(root + filename));
+    });
+    return "importScripts(" + output.join(",") + ");"
+}
+
+function run_in_worker_strict(test262, attrs, t, opts) {
+    opts = opts || {};
+    opts.strict = true;
+    run_in_worker(test262, attrs, t, opts);
+}
+
+// Run in worker.
+function run_in_worker(test262, attrs, t, opts) {
+    opts = opts || {};
+
+    let source_text = WORKER_TEMPLATE.replace('###TEST262###', prepareTest(test262, opts));
+    source_text = source_text.replace('###INCLUDES###', importScripts());
+
+    let blob = new Blob([source_text], {type: 'application/javascript'});
+    let worker = new Worker(URL.createObjectURL(blob));
+
+    worker.addEventListener('message', t.step_func(function(e) {
+        let message = e.data[0];
+        if (message == 'done') {
+            t.done();
+        }
+    }));
+
+    let FAILED = 'worker-failed' + opts.strict ? "-strict" : "";
+    worker.addEventListener('error', function(e) {
+        e.preventDefault();
+        top.dispatchEvent(new CustomEvent(FAILED, {detail: e.message}));
+    });
+    window.addEventListener(FAILED, t.step_func(function(e) {
+        console.log('fail1');
+        t.set_status(t.FAIL);
+        throw new Error(e.detail);
+    }));
+    worker.postMessage([]);
+}
+
+// Run in shared worker.
+let SHARED_WORKER_TEMPLATE = `
+    ###INCLUDES###
+
+    function createWorkerFromString(source_text) {
+        let blob = new Blob([source_text], {type: 'text/javascript'});
+        let url = URL.createObjectURL(blob);
+        return new Worker(url);
+    }
+
+    function enterEventLoop() {}
+
+    function sleep(ns) {
+        function wait(sec) {
+            let start = Date.now();
+            while (true) {
+                if (Date.now() - start > sec) {
+                    return;
+                }
+            }
+        }
+        wait(ns);
+        return {
+            then: function(fn) {
+                if (fn) { fn(); }
+            }
+        }
+    }
+
+    onconnect = function(e) {
+        function exitEventLoop(w) {
+            if (w.constructor === Array) {
+                w.forEach((w) => w.terminate());
+            } else if (typeof w === 'object') {
+                w.terminate();
+            }
+            port.postMessage(['done']);
+        }
+
+        let port = e.ports[0];
+
+        port.addEventListener('message', function(e) {
+            ###TEST262###
+        });
+
+        port.start();
+    }
+`;
+
+function run_in_shared_worker_strict(test262, attrs, t) {
+    let opts = {}
+    opts.strict = true;
+    run_in_shared_worker(test262, attrs, t, opts);
+}
+
+// Run in shared worker.
+function run_in_shared_worker(test262, attrs, t, opts) {
+    opts = opts || {};
+
+    let source_text = SHARED_WORKER_TEMPLATE.replace('###TEST262###', prepareTest(test262, opts));
+    source_text = source_text.replace('###INCLUDES###', importScripts());
+
+    let blob = new Blob([source_text], {type: 'application/javascript'});
+    let worker = new SharedWorker(URL.createObjectURL(blob));
+
+    worker.port.addEventListener('message', t.step_func(function(e) {
+        let message = e.data[0];
+        if (message == 'done') {
+            t.done();
+        }
+    }));
+
+    let FAILED = 'shared-worker-failed' + opts.strict ? "-strict" : "";
+    worker.addEventListener('error', function(e) {
+        e.preventDefault();
+        top.dispatchEvent(new CustomEvent(FAILED, {detail: e.message}));
+    });
+    window.addEventListener(FAILED, t.step_func(function(e) {
+        t.set_status(t.FAIL);
+        throw new Error(e.detail);
+    }));
+    worker.port.start();
+    worker.port.postMessage([]);
+}


### PR DESCRIPTION
This PR adds the wake/wait tests from test262 as WPT tests. These tests use the JavaScript shell agent abstraction.

The tests are not a direct import of the original test262 tests. Instead they are written using the a new proposed API. On top of that, the tests needed a few changes to be able to run in a browser. I will expand on those changes in https://github.com/tc39/test262/issues/1351

The PR also adds the harnessing code necessary to run the tests.